### PR TITLE
Changes Soulbind.md's title to match its link

### DIFF
--- a/guide/general/soulbind.md
+++ b/guide/general/soulbind.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Covenant
+title: Soulbind
 last_update: 2020-11-23 09:00:00
 game_version: 9.0.2 Shadowlands
 toc: false


### PR DESCRIPTION
This stuck out to me while reading the guide, though I could see the argument for it being Covenant. I could also see it being `Soulbinds` (plural)