### PR TITLE
General Site improvements

### DIFF
--- a/_data/affixes.yml
+++ b/_data/affixes.yml
@@ -33,7 +33,7 @@ sanguine_ichor: <a href="https://www.wowhead.com/spell=226489/sanguine-ichor" ta
 
 # Tier 7
 explosive: <a href="https://www.wowhead.com/affix=13/explosive" target="blank">Explosive</a>
-explosives: <a href="https://www.wowhead.com/spell=243180/explosives" target="blank">Explosives</a>
+explosives: <a href="https://www.wowhead.com/npc=120651/explosives" target="blank">Explosives</a>
 explosion: <a href="https://www.wowhead.com/spell=240446/explosion" target="blank">Explosion</a>
 storming: <a href="https://www.wowhead.com/affix=124/storming" target="blank">Storming</a>
 volcanic: <a href="https://www.wowhead.com/affix=3/volcanic" target="blank">Volcanic</a>

--- a/_data/dungeon/aa.yml
+++ b/_data/dungeon/aa.yml
@@ -86,6 +86,7 @@ branch_out: <a href="https://www.wowhead.com/spell=388623/branch-out" target="bl
 ancient_branch: <a href="https://www.wowhead.com/npc=196548/ancient-branch" target="blank">Ancient Branch</a>
 healing_touch: <a href="https://www.wowhead.com/spell=396640/healing-touch" target="blank">Healing Touch</a>
 barkbreaker: <a href="https://www.wowhead.com/spell=388544/barkbreaker" target="blank">Barkbreaker</a>
+splinterbark: <a href="https://www.wowhead.com/spell=396716/splinterbark" target="blank">Splinterbark</a>
 
 # Echo of Doragosa trash
 algethar_echoknight: <a href="https://www.wowhead.com/npc=196200/algethar-echoknight" target="blank">Algeth'ar Echoknight</a>

--- a/_data/item.yml
+++ b/_data/item.yml
@@ -28,12 +28,12 @@ phial_eits: <a href="https://www.wowhead.com/item=191320/phial-of-the-eye-in-the
 phial_sa: <a href="https://www.wowhead.com/item=191321/phial-of-still-air" target="blank">Phial of Still Air</a>
 phial_ip: <a href="https://www.wowhead.com/item=191325/phial-of-icy-preservation" target="blank">Phial of Icy Preservation</a>
 phial_cr: <a href="https://www.wowhead.com/item=191327/iced-phial-of-corrupting-rage" target="blank">Iced Phial of Corrupting Rage</a>
-phial_ci: <a href="https://www.wowhead.com/item=191330/phial-of-charged-isolation" target="blank">Phial of Charged Isolation</a>
-phial_gf: <a href="https://www.wowhead.com/item=191333/phial-of-glacial-fury" target="blank">Phial of Glacial Fury</a>
-phial_se: <a href="https://www.wowhead.com/item=191336/phial-of-static-empowerment" target="blank">Phial of Static Empowerment</a>
-phial_tv: <a href="https://www.wowhead.com/item=191339/phial-of-tepid-versatility" target="blank">Phial of Tepid Versatility</a>
+phial_ci: <a href="https://www.wowhead.com/item=191332/phial-of-charged-isolation" target="blank">Phial of Charged Isolation</a>
+phial_gf: <a href="https://www.wowhead.com/item=191335/phial-of-glacial-fury" target="blank">Phial of Glacial Fury</a>
+phial_se: <a href="https://www.wowhead.com/item=191338/phial-of-static-empowerment" target="blank">Phial of Static Empowerment</a>
+phial_tv: <a href="https://www.wowhead.com/item=191341/phial-of-tepid-versatility" target="blank">Phial of Tepid Versatility</a>
 phial_a: <a href="https://www.wowhead.com/item=191348/charged-phial-of-alacrity" target="blank">Charged Phial of Alacrity</a>
-phial_ec: <a href="https://www.wowhead.com/item=191357/phial-of-elemental-chaos" target="blank">Phial of Elemental Chaos</a>
+phial_ec: <a href="https://www.wowhead.com/item=191359/phial-of-elemental-chaos" target="blank">Phial of Elemental Chaos</a>
 
 # DF Potions
 potion_bp: <a href="https://www.wowhead.com/item=191362/bottled-putrescence" target="blank">Bottled Putrescence</a>
@@ -43,13 +43,13 @@ potion_cc: <a href="https://www.wowhead.com/item=191366/potion-of-chilled-clarit
 potion_wv: <a href="https://www.wowhead.com/item=191369/potion-of-withering-vitality" target="blank">Potion of Withering Vitality</a>
 potion_rnca: <a href="https://www.wowhead.com/item=191372/residual-neural-channeling-agent" target="blank">Residual Neural Channeling Agent</a>
 potion_ss: <a href="https://www.wowhead.com/item=191375/delicate-suspension-of-spores" target="blank">Delicate Suspension of Spores</a>
-potion_rhp: <a href="https://www.wowhead.com/item=191378/refreshing-healing-potion" target="blank">Refreshing Healing Potion</a>
+potion_rhp: <a href="https://www.wowhead.com/item=191380/refreshing-healing-potion" target="blank">Refreshing Healing Potion</a>
 potion_amp: <a href="https://www.wowhead.com/item=191384/aerated-mana-potion" target="blank">Aerated Mana Potion</a>
-potion_p: <a href="https://www.wowhead.com/item=191387/elemental-potion-of-power" target="blank">Elemental Potion of Power</a>
-potion_up: <a href="https://www.wowhead.com/item=191381/elemental-potion-of-ultimate-power" target="blank">Elemental Potion of Ultimate Power</a>
+potion_p: <a href="https://www.wowhead.com/item=191389/elemental-potion-of-power" target="blank">Elemental Potion of Power</a>
+potion_up: <a href="https://www.wowhead.com/item=191383/elemental-potion-of-ultimate-power" target="blank">Elemental Potion of Ultimate Power</a>
 potion_hz: <a href="https://www.wowhead.com/item=191393/potion-of-the-hushed-zephyr" target="blank">Potion of the Hushed Zephyr</a>
 potion_g: <a href="https://www.wowhead.com/item=191396/potion-of-gusts" target="blank">Potion of Gusts</a>
-potion_sd: <a href="https://www.wowhead.com/item=191399/potion-of-shocking-disclosure" target="blank">Potion of Shocking Disclosure</a>
+potion_sd: <a href="https://www.wowhead.com/item=191401/potion-of-shocking-disclosure" target="blank">Potion of Shocking Disclosure</a>
 
 # DF Food
 food_int: <a href="https://www.wowhead.com/item=197792/fated-fortune-cookie" target="blank">Fated Fortune Cookie</a>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -32,7 +32,7 @@ layout: default
       {%- else -%}
         {%- include toc.html html=content class="toc" h_max=3 -%}
       {%- endif -%}
-      <p align="center"><img src="/assets/img/blog/bluelinebreak.png" width="130%"/></p>
+      <hr>
     {%- endif -%}
     {{ content }}
   </div>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -27,9 +27,12 @@ layout: default
     {%- include side_menu.html -%}
     {%- if page.toc == true -%}
       <h3>Table of Contents</h3>
-      {%- include toc.html html=content class="toc" h_max=3 -%}
-      <hr>
-      <br>
+      {%- if page.big_article == true -%}
+        {%- include toc.html html=content class="toc" h_max=1 -%}
+      {%- else -%}
+        {%- include toc.html html=content class="toc" h_max=3 -%}
+      {%- endif -%}
+      <p align="center"><img src="/assets/img/blog/bluelinebreak.png" width="130%"/></p>
     {%- endif -%}
     {{ content }}
   </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -20,7 +20,7 @@ layout: default
     {%- if page.toc == true -%}
       <h3>Table of Contents</h3>
       {%- include toc.html html=content class="toc" h_max=3 -%}
-      <p align="center"><img src="/assets/img/blog/bluelinebreak.png" width="130%"/></p>
+      <hr>
       <br>
     {%- endif -%}
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -20,7 +20,7 @@ layout: default
     {%- if page.toc == true -%}
       <h3>Table of Contents</h3>
       {%- include toc.html html=content class="toc" h_max=3 -%}
-      <hr>
+      <p align="center"><img src="/assets/img/blog/bluelinebreak.png" width="130%"/></p>
       <br>
     {%- endif -%}
 

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -169,7 +169,12 @@ ul {
 
 // adjust hr to match the page dark theme
 hr {
-  border-top: 1px solid $grey-color;
+  // border-top: 1px solid $grey-color;
+  display: block;
+  border: 0px;
+  height: 26px;
+  background-image: url('/assets/img/blog/bluelinebreak.png');
+  background-repeat: no-repeat;
 }
 
 // APL list spacing

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -175,6 +175,7 @@ hr {
   height: 26px;
   background-image: url('/assets/img/blog/bluelinebreak.png');
   background-repeat: no-repeat;
+  background-position: center;
 }
 
 // APL list spacing

--- a/guide/general/builds.md
+++ b/guide/general/builds.md
@@ -1,9 +1,10 @@
 ---
 layout: page
 title: Builds
-last_update: 22/03/2023
+last_update: 29/03/2023
 game_version: 10.0.7 Dragonflight
-toc: false
+toc: true
+big_article: true
 ---
 
 # Welcome, read First
@@ -11,7 +12,7 @@ toc: false
 This page aims to display and discuss the recommended and most widely-used Builds available to Elemental. This is not an exhaustive list of all options and *does not imply that any build **not** shown here is automatically terrible/unplayable*.  
 In practical terms we cannot account for every build variation and effort has been largely focused on the highest performing / most popular builds. If you find something that you feel works or performs better than what is listed here feel free to contact the team on [Storm, Earth & Lava Discord](https://discord.gg/y5dUf3PWrU) or [Earthshrine #Elemental Channel](https://discord.gg/earthshrine)
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png" width="130%"/></p>
 
 # Class Tree
 
@@ -32,8 +33,8 @@ More situational talents picks:
 * Defensive:
   - {{ site.data.talent.natures_guardian }} and {{ site.data.talent.ancestral_defence }} and {{ site.data.talent.elemental_warding }} are good sustain passives.
   - {{ site.data.talent.ee }} is a bad defensive since its CD is so long, but it's a defensive CD nonetheless and has good value in many situation.
-  - {{ site.data.talent.earth_shield }} is a good sustain talent, just remember to refresh it when it falls off. It's also annoying to get since we almost never press {{ site.data.talent.chain_heal}}.
-  - {{ site.data.talent.brimming_with_life }} is a terribly designed talent that incites us to save {{ site.data.spell.ankh }} for more max HP. It is still better than nothing for an increase in survivability and overall ankh uses.
+  - {{ site.data.talent.earth_shield }} is a good sustain talent, just remember to refresh it when it falls off. It's also annoying to get since we almost never press {{ site.data.talent.chain_heal }}.
+  - {{ site.data.talent.brimming_with_life }} is a terribly designed talent that incites us to save {{ site.data.spell.ankh }} for more max HP. It is still better than nothing for an increase in survivability and overall {{ site.data.spell.ankh }} uses.
   - {{ site.data.talent.healing_stream_totem }}, paired with {{ site.data.talent.swirling_currents }}, is a fire and forget heal assistance on the GCD. It's not bad but certainly not great.
 * Movement:
   - {{ site.data.talent.thunderous_paws }} is great for small burst of mobility and slow dispel, {{ site.data.talent.spirit_wolf }} is a great "long-distance" movement tool.
@@ -45,7 +46,7 @@ More situational talents picks:
   - {{ site.data.talent.purge }} and {{ site.data.talent.cleanse_spirit }} are perfect examples of good talents that are purely situational and can be skipped in many builds, and picked only when needed.
   - {{ site.data.talent.capacitor_totem }}, {{ site.data.talent.hex }}, {{ site.data.talent.earthgrab_totem }} or {{ site.data.talent.thunderstorm }} are situational Crowd Control talents.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png" width="130%"/></p>
 
 # Hotfixes applied on 28/02/23 (NA) and 01/03/23 (EU):
 First and foremost, they do not appear to have any impact on rotational priority from initial testing. This includes but is not limited to:
@@ -54,13 +55,13 @@ First and foremost, they do not appear to have any impact on rotational priority
    - For those using {{ site.data.talent.mwf }} builds remember the priority has not changed, the build just has less sources of {{ site.data.talent.lvs }} procs relative to the alternative {{ site.data.talent.wlr }} build.
    - Some players were already including {{ site.data.talent.icefury }} with {{ site.data.talent.e_shocks }} into the Wildfire builds (trading {{ site.data.talent.fop }} for them), this choice gained some ground with the buff to baseline {{ site.data.spell.frs }} damage and the maelstrom gains of {{ site.data.talent.if }} buffs.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
-
-<p style="color:red">Click on a build banner to expand it.</p>
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png" width="130%"/></p>
 
 # Primordial Surge Builds
 
 Most notably aimed more at the Single Target profiles these variants are used when you need to focus on boss damage by using the inherent strength of combining {{ site.data.talent.ps }} and tools like {{ site.data.talent.dre }} and/or {{ site.data.talent.wlr }} to increase the value and frequency of {{ site.data.talent.lvs }}. Turning your {{ site.data.talent.eb }} and {{ site.data.spell.lvb }} into powerhouses.
+
+<p align="center" style="color:red">Click on a build banner to expand it.</p>
 
 <div class="accordion dungeon-accordion" id="accordion-psurge">
 <div class="card">
@@ -70,43 +71,43 @@ Most notably aimed more at the Single Target profiles these variants are used wh
 <div id="pswlr-collapse" class="collapse" aria-labelledby="pswlr" data-parent="#accordion-psurge">
 <div class="card-body" markdown="1">
 
-# What does this build do?
+## What does this build do?
 
 This build works around the damage of {{ site.data.spell.lvb }} and {{ site.data.talent.eb }}, supported by the idea of {{ site.data.talent.pw }} 'windows'.
 As the name suggests this is predominately aimed at single target but due to taking {{ site.data.talent.lvs }}, {{ site.data.talent.magma_chamber }} and {{ site.data.talent.pw }} it will naturally benefit from a couple of additional targets.
 
-# What does it look like?
+## What does it look like?
 
-## Standard build
+### Standard build
 {{ site.data.talent.eeq }} is *usually* the best single point to get for a Single Target fight. Be sure to sim for your best option.
 <div class="iframe-holder">
   <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAgUSr0SCgDkUSShSUikQEAAAAAgSAJlkgmASLJpBCCJJBC?width=530&level=70" frameborder="0" width="530px" height="100%"></iframe>
 </div>
 
-## LMT Variant
+### LMT Variant
 {{ site.data.talent.lmt }} can be used on fight with some adds to gain some cleave but where the only thing that matters is Single Target (such as Sennarth).
 <div class="iframe-holder">
   <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAgUSr0SCAJlkUoEl0SCRAAAAAAKBIlkgmASLJppECSkEgA?width=530&level=70" frameborder="0" width="530px" height="100%"></iframe>
 </div>
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-# Stats
+## Stats
 
-## Always remember to sim your current options appropriately
+### Always remember to sim your current options appropriately
  - [Raidbots](https://www.raidbots.com/simbot/topgear)
  - For more information [How Does Elemental Sim?]({{ site.baseurl }}{% link blog/_posts/2023-01-02-simming.md %})
 
-## Simplified
+### Simplified
 This is quick and dirty, your sims will take priority in your gearing process.
  - Mastery / Haste >> Versatility = Crit
  - Remember that generally Haste will make the rotation easier to execute and further improve your ability to adapt to movement so will always be a solid stat to go for, and more flexible than Mastery given Haste is also very good in all AoE-focused builds
 
- ![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-# Rotation
+## Rotation
 
-## Key Notes
+### Key Notes
  - Straightforward loop: cast your cooldowns, use {{ site.data.spell.lvb }}, use {{ site.data.talent.eb }}, {{ site.data.talent.if }} and {{ site.data.spell.frs}} become improved filler spells.
  - Don't forget that {{ site.data.talent.wlr }} provides a {{ site.data.talent.lvs }} proc after each {{ site.data.talent.eb }}! Use these immediately afterwards in all cases!
  - {{ site.data.talent.if }} and {{ site.data.spell.frs}} become movement-enabling globals when more than one target is present.
@@ -115,7 +116,7 @@ This is quick and dirty, your sims will take priority in your gearing process.
  - {{ site.data.talent.dre }} procs do not impact rotation priority and should be read the same regardless. In practice this means 'filler' spells like {{ site.data.talent.if }} and buffed {{ site.data.spell.frs }} are eliminated when {{ site.data.talent.dre }} procs happen *unless you have to move* because {{ site.data.spell.lvb }} will always be available during them. You will also continue to spend maelstrom on {{ site.data.talent.eb }} as usual.
  - If talented, use {{ site.data.talent.lmt }} on CD if no adds are going to spawn soon.
 
-## Opener
+### Opener
 Follow the cast sequence below for your opener. A <span style="color:red">red arrow</span> indicates the time the boss is pulled. Please note that openers are a *very* minor and nit-picky increase (or sometimes decrease!), and adapting to the fight is much more important.
 
 ~3.5 seconds from pull
@@ -130,7 +131,7 @@ Follow the cast sequence below for your opener. A <span style="color:red">red ar
     <div class="arrow"></div>...
 </div>
 
-## 1 Target Priority
+### 1 Target Priority
  - {{ site.data.talent.fe }} if it is available and there is no reason to hold its use.
  - {{ site.data.talent.pw }} if it is available
  - {{ site.data.spell.lvb }} if {{ site.data.talent.lvs }} buff is active, even if this would make you overcap maelstrom!
@@ -140,7 +141,7 @@ Follow the cast sequence below for your opener. A <span style="color:red">red ar
  - {{ site.data.talent.icefury }}
  - {{ site.data.spell.lb }}
 
-## 2 Targets Priority
+### 2 Targets Priority
 If you find yourself using this build on 2 or more targets it is less than ideal.
  - {{ site.data.talent.fe }} if it is available and there is no reason to hold its use.
  - Maintain {{ site.data.spell.fs }} on both targets at all times, don't forget {{ site.data.talent.pw }} applies one!
@@ -150,7 +151,7 @@ If you find yourself using this build on 2 or more targets it is less than ideal
  - {{ site.data.spell.lvb }}
  - {{ site.data.spell.cl }}
 
-## 3 Targets Priority
+### 3 Targets Priority
 If you find yourself using this build on 3 or more targets it is less than ideal
  - {{ site.data.talent.fe }} if it is available and there is no reason to hold its use.
  - Maintain {{ site.data.spell.fs }} on all targets at all times, don't forget {{ site.data.talent.pw }} applies one!
@@ -160,7 +161,7 @@ If you find yourself using this build on 3 or more targets it is less than ideal
  - {{ site.data.spell.lvb }}
  - {{ site.data.spell.cl }}
 
-## 4 Targets Priority
+### 4 Targets Priority
 If you find yourself using this build on 4 or more targets it is less than ideal
  - {{ site.data.talent.fe }} if it is available and there is no reason to hold its use.
  - Maintain {{ site.data.spell.fs }} on all targets at all times, don't forget {{ site.data.talent.pw }} applies one!
@@ -170,7 +171,7 @@ If you find yourself using this build on 4 or more targets it is less than ideal
  - {{ site.data.spell.lvb }}
  - {{ site.data.spell.cl }}
 
-## 5+ Targets Priority
+### 5+ Targets Priority
 If you find yourself using this build on 5 or more targets it is less than ideal
  - {{ site.data.talent.fe }} if it is available and there is no reason to hold its use.
  - Maintain {{ site.data.spell.fs }} on all targets at all times, don't forget {{ site.data.talent.pw }} applies one!
@@ -191,43 +192,43 @@ If you find yourself using this build on 5 or more targets it is less than ideal
 <div id="psfb-collapse" class="collapse" aria-labelledby="psfb" data-parent="#accordion-psurge">
 <div class="card-body" markdown="1">
 
-# What does this build do?
+## What does this build do?
 
 This build works around the damage of {{ site.data.spell.lvb }} and {{ site.data.talent.eb }}, supported by the idea of {{ site.data.talent.pw }} 'windows'.
 As this build takes {{ site.data.talent.dre }} and extends to {{ site.data.talent.fb }} a fair amount of its power comes from maximizing {{ site.data.spell.lvb }} usage, particularly {{ site.data.talent.lvs }}, to have the most chances at gambling {{ site.data.talent.dre }} which {{ site.data.talent.ps }} naturally assists with.
 
-# What does it look like?
+## What does it look like?
 
-## Standard build
+### Standard build
 {{ site.data.talent.eeq }} is *usually* the best single point to get for a Single Target fight. Be sure to sim for your best option.
 <div class="iframe-holder">
   <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAgUSr0SCgDkUSSJpEIJEBAAAAAoEQSJJoJg0SSaggQSSgA?width=530&level=70" frameborder="0" width="530px" height="100%"></iframe>
 </div>
 
-## LMT Variant
+### LMT Variant
 {{ site.data.talent.lmt }} can be used on fight with some adds to gain some cleave but where the only thing that matters is Single Target (such as Sennarth).
 <div class="iframe-holder">
   <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAgUSr0SCAJlkUSKBtkQEAAAAAgSASJJoJg0SSaKhgEJBI?width=530&level=70" frameborder="0" width="530px" height="100%"></iframe>
 </div>
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-# Stats
+## Stats
 
-## Always remember to sim your current options appropriately
+### Always remember to sim your current options appropriately
  - [Raidbots](https://www.raidbots.com/simbot/topgear)
  - For more information [How Does Elemental Sim?]({{ site.baseurl }}{% link blog/_posts/2023-01-02-simming.md %})
 
-## Simplified
+### Simplified
 This is quick and dirty, your sims will take priority in your gearing process.
  - Haste >> Mastery > Versatility = Crit
  - Remember that generally Haste will make the rotation easier to execute and further improve your ability to adapt to movement so will always be a solid stat to go for, and more flexible than Mastery given Haste is also very good in all AoE-focused builds
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-# Rotation
+## Rotation
 
-## Key Notes
+### Key Notes
  - This variant includes {{ site.data.talent.fb }} which will inevitably increase the pull-to-pull variance in your damage that you see in-game *and* is not simulated with movement in mind when using default Patchwerk sims, this means it may not be the proper choice in real raid scenarios if you're looking to do the most damage and more importantly if you need to do that damage consistently and reliably! It is however extremely fun to manage procs and highroll, best of luck to you!
  - Straightforward loop: cast your cooldowns, use {{ site.data.spell.lvb }}, use {{ site.data.talent.eb }}, {{ site.data.talent.if }} and {{ site.data.spell.frs}} become improved filler spells.
  - {{ site.data.talent.if }} and {{ site.data.spell.frs}} become movement-enabling globals when more than one target is present.
@@ -237,7 +238,7 @@ This is quick and dirty, your sims will take priority in your gearing process.
  - {{ site.data.talent.fb }} makes you value maelstrom generation very highly during AoE, which displaces regular {{ site.data.spell.lvb }} casts entirely at 4+ targets. This is predominately a single-target build so AoE is not its main function.
  - If talented, use {{ site.data.talent.lmt }} on CD if no adds are going to spawn soon.
 
-## Opener
+### Opener
 Follow the cast sequence below for your opener. A <span style="color:red">red arrow</span> indicates the time the boss is pulled. Please note that openers are a *very* minor and nit-picky increase (or sometimes decrease!), and adapting to the fight is much more important.
 
 ~3.5 seconds from pull
@@ -252,7 +253,7 @@ Follow the cast sequence below for your opener. A <span style="color:red">red ar
     <div class="arrow"></div>...
 </div>
 
-## 1 Target Priority
+### 1 Target Priority
  - {{ site.data.talent.fe }} if it is available and there is no reason to hold its use.
  - {{ site.data.talent.pw }} if it is available
  - {{ site.data.spell.lvb }} if {{ site.data.talent.lvs }} buff is active, even if this would make you overcap maelstrom!
@@ -264,7 +265,7 @@ Follow the cast sequence below for your opener. A <span style="color:red">red ar
  - {{ site.data.spell.lb }}
     *  {{ site.data.talent.eb }} is only listed when {{ site.data.talent.dre }} proc or maelstrom overcap would happen because you want to enter these procs with as high maelstrom as possible due to {{ site.data.talent.fb }}, in an ideal world you would only spend during {{ site.data.talent.dre }} procs but inevitably you will need to avoid overcapping outside of these procs as well.
 
-## 2 Targets Priority
+### 2 Targets Priority
 If you find yourself using this build on 2 or more targets it is less than ideal.
  - {{ site.data.talent.fe }} if it is available and there is no reason to hold its use.
  - Maintain {{ site.data.spell.fs }} on both targets at all times, don't forget {{ site.data.talent.pw }} applies one!
@@ -277,7 +278,7 @@ If you find yourself using this build on 2 or more targets it is less than ideal
  - {{ site.data.spell.frs }} if you have {{ site.data.talent.if }} buff active *and* need to move
  - {{ site.data.talent.if }} if you expect to move soon and {{ site.data.talent.swg }} is not available, otherwise do not use.
 
-## 3 Targets Priority
+### 3 Targets Priority
 If you find yourself using this build on 3 or more targets it is less than ideal
  - {{ site.data.talent.fe }} if it is available and there is no reason to hold its use.
  - Maintain {{ site.data.spell.fs }} on all targets at all times, don't forget {{ site.data.talent.pw }} applies one!
@@ -288,7 +289,7 @@ If you find yourself using this build on 3 or more targets it is less than ideal
  - {{ site.data.spell.lvb }}
  - {{ site.data.spell.cl }}
 
-## 4 Targets Priority
+### 4 Targets Priority
 If you find yourself using this build on 4 or more targets it is less than ideal
  - {{ site.data.talent.fe }} if it is available and there is no reason to hold its use.
  - Maintain {{ site.data.spell.fs }} on all targets at all times, don't forget {{ site.data.talent.pw }} applies one!
@@ -298,7 +299,7 @@ If you find yourself using this build on 4 or more targets it is less than ideal
  - {{ site.data.spell.lvbm }} if {{ site.data.talent.dre }} proc is active and you will finish the cast
  - {{ site.data.spell.cl }}
 
-## 5+ Targets Priority
+### 5+ Targets Priority
 If you find yourself using this build on 5 or more targets it is less than ideal
  - {{ site.data.talent.fe }} if it is available and there is no reason to hold its use.
  - Maintain {{ site.data.spell.fs }} on all targets at all times, don't forget {{ site.data.talent.pw }} applies one!
@@ -319,43 +320,43 @@ If you find yourself using this build on 5 or more targets it is less than ideal
 <div id="psmwf-collapse" class="collapse" aria-labelledby="psmwf" data-parent="#accordion-psurge">
 <div class="card-body" markdown="1">
 
-# What does this build do?
+## What does this build do?
 
 This build works around the damage of {{ site.data.spell.lvb }} and {{ site.data.talent.eb }}, supported by the idea of {{ site.data.talent.pw }} 'windows'.
 This build effectively swaps {{ site.data.talent.wlr }} or {{ site.data.talent.fb }} for {{ site.data.talent.mwf }}, which reduces the perceived complexity from this build allowing you to focus more completely on the {{ site.data.talent.lvs }} provided by {{ site.data.talent.ps }} and effective spending of maelstrom.
 
-# What does it look like?
+## What does it look like?
 
-## Standard build
+### Standard build
 {{ site.data.talent.eeq }} is *usually* the best single point to get for a Single Target fight. Be sure to sim for your best option.
 <div class="iframe-holder">
   <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAgUSr0SCgDkUSShSgkkEBAAAAAoEQSJJoJg0SSaggQSSgA?width=530&level=70" frameborder="0" width="530px" height="100%"></iframe>
 </div>
 
-## LMT Variant
+### LMT Variant
 {{ site.data.talent.lmt }} can be used on fight with some adds to gain some cleave but where the only thing that matters is Single Target (such as Sennarth).
 <div class="iframe-holder">
   <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAgUSr0SCAJlkUoE0SSSEAAAAAgSASJJoJg0SSaKhgEJBI?width=530&level=70" frameborder="0" width="530px" height="100%"></iframe>
 </div>
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-# Stats
+## Stats
 
-## Always remember to sim your current options appropriately
+### Always remember to sim your current options appropriately
  - [Raidbots](https://www.raidbots.com/simbot/topgear)
  - For more information [How Does Elemental Sim?]({{ site.baseurl }}{% link blog/_posts/2023-01-02-simming.md %})
 
-## Simplified
+### Simplified
 This is quick and dirty, your sims will take priority in your gearing process.
  - Haste / Mastery > Versatility = Crit
  - Remember that generally Haste will make the rotation easier to execute and further improve your ability to adapt to movement so will always be a solid stat to go for, and more flexible than Mastery given Haste is also very good in all AoE-focused builds
 
- ![Line Break](/assets/img/blog/bluelinebreak.png)
+ <p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-# Rotation
+## Rotation
 
-## Key Notes
+### Key Notes
  - Straightforward loop: cast your cooldowns, use {{ site.data.spell.lvb }}, use {{ site.data.talent.eb }}, {{ site.data.talent.if }} and {{ site.data.spell.frs}} become improved filler spells.
  - {{ site.data.talent.if }} and {{ site.data.spell.frs}} become movement-enabling globals when more than one target is present.
  - Due to elements like {{ site.data.talent.ps }} and {{ site.data.talent.dre }} with its supporting talents you should continue to utilize {{ site.data.talent.lvs }} procs even if you end up facing multiple targets.
@@ -364,7 +365,7 @@ This is quick and dirty, your sims will take priority in your gearing process.
  - If talented, use {{ site.data.talent.lmt }} on CD if no adds are going to spawn soon.
  - {{ site.data.talent.lmt }}’s periodic damage scales dynamically with haste, therefore it can be used to setup a pull by applying {{ site.data.spell.fs }} before gaining the {{ site.data.talent.splinter }} haste buff without losing out on too much potential damage. You should still aim to use {{ site.data.talent.lmt }} while having the {{ site.data.talent.splinter }} haste buff or {{ site.data.spell.bl }} if possible, but don't lose setup time for it.
 
-## Opener
+### Opener
 Follow the cast sequence below for your opener. A <span style="color:red">red arrow</span> indicates the time the boss is pulled. Please note that openers are a *very* minor and nit-picky increase (or sometimes decrease!), and adapting to the fight is much more important.
 
 ~3.5 seconds from pull
@@ -379,7 +380,7 @@ Follow the cast sequence below for your opener. A <span style="color:red">red ar
     <div class="arrow"></div>...
 </div>
 
-## 1 Target Priority
+### 1 Target Priority
  - {{ site.data.talent.fe }} if it is available and there is no reason to hold its use.
  - {{ site.data.talent.pw }} if it is available
  - {{ site.data.spell.lvb }} if {{ site.data.talent.lvs }} buff is active, even if this would make you overcap maelstrom!
@@ -389,7 +390,7 @@ Follow the cast sequence below for your opener. A <span style="color:red">red ar
  - {{ site.data.talent.icefury }}
  - {{ site.data.spell.lb }}
 
-## 2 Targets Priority
+### 2 Targets Priority
 If you find yourself using this build on 2 or more targets it is less than ideal.
  - {{ site.data.talent.fe }} if it is available and there is no reason to hold its use.
  - Maintain {{ site.data.spell.fs }} on both targets at all times, don't forget {{ site.data.talent.pw }} applies one!
@@ -401,7 +402,7 @@ If you find yourself using this build on 2 or more targets it is less than ideal
  - {{ site.data.spell.frs }} if you have {{ site.data.talent.if }} buff active *and* need to move
  - {{ site.data.talent.if }} if you expect to move soon and {{ site.data.talent.swg }} is not available, otherwise do not use.
 
-## 3 Targets Priority
+### 3 Targets Priority
 If you find yourself using this build on 3 or more targets it is less than ideal
  - {{ site.data.talent.fe }} if it is available and there is no reason to hold its use.
  - Maintain {{ site.data.spell.fs }} on all targets at all times, don't forget {{ site.data.talent.pw }} applies one!
@@ -411,7 +412,7 @@ If you find yourself using this build on 3 or more targets it is less than ideal
  - {{ site.data.spell.lvb }}
  - {{ site.data.spell.cl }}
 
-## 4 Targets Priority
+### 4 Targets Priority
 If you find yourself using this build on 4 or more targets it is less than ideal
  - {{ site.data.talent.fe }} if it is available and there is no reason to hold its use.
  - Maintain {{ site.data.spell.fs }} on all targets at all times, don't forget {{ site.data.talent.pw }} applies one!
@@ -421,7 +422,7 @@ If you find yourself using this build on 4 or more targets it is less than ideal
  - {{ site.data.spell.lvbm }} if {{ site.data.talent.dre }} proc is active and you will finish the cast (if you will not, revert to {{ site.data.spell.lvb }}
  - {{ site.data.spell.cl }}
 
-## 5+ Targets Priority
+### 5+ Targets Priority
 If you find yourself using this build on 5 or more targets it is less than ideal
  - {{ site.data.talent.fe }} if it is available and there is no reason to hold its use.
  - Maintain {{ site.data.spell.fs }} on all targets at all times, don't forget {{ site.data.talent.pw }} applies one!
@@ -442,36 +443,36 @@ If you find yourself using this build on 5 or more targets it is less than ideal
 <div id="pssk-collapse" class="collapse" aria-labelledby="pssk" data-parent="#accordion-psurge">
 <div class="card-body" markdown="1">
 
-# What does this build do?
+## What does this build do?
 
 This is a Single Target build that allows Regular AoE Burst. It is best used on fights like Eranog or Dungeon like Court of Stars.
 This build works around the damage of {{ site.data.spell.lvb }} and {{ site.data.talent.eb }}, supported by the idea of {{ site.data.talent.pw }} 'windows'. But it also uses {{ site.data.talent.sk }} and {{ site.data.talent.sop }} to empower our burst potential, both in ST and in AoE.
 This build can be harder to play effectively as it requires you to play around both {{ site.data.talent.pw }} 'windows' and the combination of  {{ site.data.talent.sop }} with {{ site.data.talent.sk }}.
 
-# What does it look like?
+## What does it look like?
 <div class="iframe-holder">
 <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAgUSrIJtkEkg0oE0kkkDAAAAAAoEgUSCaCItkkmSIIRSAC?width=530&level=70" frameborder="0" width="530px" height="100%"></iframe>
   </div>
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-# Stats
+## Stats
 
-## Always remember to sim your current options appropriately
+### Always remember to sim your current options appropriately
  - [Raidbots](https://www.raidbots.com/simbot/topgear)
  - For more information [How Does Elemental Sim?]({{ site.baseurl }}{% link blog/_posts/2023-01-02-simming.md %})
 
-## Simplified
+### Simplified
 This is quick and dirty, your sims will take priority in your gearing process.
  - Haste / Mastery > Versatility = Crit
  - Remember that generally Haste will make the rotation easier to execute and further improve your ability to adapt to movement so will always be a solid stat to go for, and more flexible than Mastery given Haste is also very good in all AoE-focused builds
  - Mastery has very good synergy with both {{ site.data.talent.mwf }} and {{ site.data.spell.lvb }}.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-# Rotation
+## Rotation
 
-## Key Notes
+### Key Notes
 - This build is best used on single target fights with regular Adds spawns or burst windows.
 - {{ site.data.talent.sop }} is there to amplify what you're already aiming to do at different target counts which can be quite handy, whilst it is appreciable that {{ site.data.talent.eb }} reduces the value gained from {{ site.data.talent.sop }} due to being more expensive and producing less buffs overall - this is only true for the 1-4 target range and the value added is still positive, AoE value from {{ site.data.talent.sop }} is unaffected at 6+ targets.
     * 1-2 Targets = {{ site.data.spell.lb }} (or {{site.data.spell.lvb}} on {{ site.data.talent.dre }} procs)
@@ -482,7 +483,7 @@ This is quick and dirty, your sims will take priority in your gearing process.
 - {{ site.data.spell.eq }} replaces {{ site.data.talent.eb }} at 4 or more targets.
 - {{ site.data.talent.lmt }} is included for its raw damage, don't start to spread {{ site.data.spell.fs }} unless you have to move - in which case it remains a good movement global.
 
-## Opener
+### Opener
 Follow the cast sequence below for your opener. A <span style="color:red">red arrow</span> indicates the time the boss is pulled. Please note that openers are a *very* minor and nit-picky increase (or sometimes decrease!), and adapting to the fight is much more important.
 
 ~4.5 seconds from pull
@@ -499,7 +500,7 @@ Follow the cast sequence below for your opener. A <span style="color:red">red ar
     <div class="arrow"></div>...
 </div>
 
-## 1 Target Priority
+### 1 Target Priority
  - {{ site.data.talent.fe }} if it is available and there is no reason to hold its use.
  - {{ site.data.talent.lmt }} if it is available and no additional targets soon. (using {{ site.data.talent.totemic_recall }} is dps neutral in single target, and could be considered a good movement global if none are available and it would not negatively impact the next use)
  - {{ site.data.talent.sk }} if you have an active {{ site.data.talent.sop }} buff and at least 46 maelstrom. This will enable you to buff both of your {{ site.data.talent.sk }} charges if you cast {{ site.data.spell.lvb }} before your second {{ site.data.talent.eb }} cast.
@@ -513,7 +514,7 @@ Follow the cast sequence below for your opener. A <span style="color:red">red ar
  - {{ site.data.spell.lb }} if {{ site.data.talent.sk }} is active
  - {{ site.data.spell.lb}}
 
-## 2 Targets Priority
+### 2 Targets Priority
  - {{ site.data.talent.fe }} if it is available and there is no reason to hold its use.
  - {{ site.data.talent.lmt }} if it is available and no additional targets soon. (using {{ site.data.talent.totemic_recall }} is dps neutral in single target, and could be considered a good movement global if none are available and it would not negatively impact the next use)
  - {{ site.data.talent.sk }} if you have an active {{ site.data.talent.sop }} buff and at least 46 maelstrom. This will enable you to buff both of your {{ site.data.talent.sk }} charges if you cast {{ site.data.spell.lvb }} before your second {{ site.data.talent.eb }} cast.
@@ -529,7 +530,7 @@ Follow the cast sequence below for your opener. A <span style="color:red">red ar
   Note:
  - Playing around {{ site.data.talent.potm }} procs is dps neutral, but generally it will be easier and less likely to negatively impact your performance if you ignore them - sometimes you will get lucky and have one during your {{ site.data.talent.sk }} burst though!
 
-## 3 Targets Priority
+### 3 Targets Priority
  - {{ site.data.talent.fe }} if it is available and there is no reason to hold its use.
  - {{ site.data.talent.lmt }} if it is available and no additional targets soon. (using {{ site.data.talent.totemic_recall }} is dps neutral in single target, and could be considered a good movement global if none are available and it would not negatively impact the next use)
  - Maintain {{ site.data.spell.fs }} on all targets at all times, don't forget {{ site.data.talent.pw }} applies one and {{ site.data.talent.sop }} spreads it!
@@ -558,7 +559,7 @@ Follow the cast sequence below for your opener. A <span style="color:red">red ar
  - {{ site.data.spell.lvb }}
  - {{ site.data.spell.cl }}
 
-## 6+ Targets Priority
+### 6+ Targets Priority
  - {{ site.data.talent.fe }} if it is available and there is no reason to hold its use.
  - {{ site.data.talent.lmt }} if it is available and no additional targets soon. (using {{ site.data.talent.totemic_recall }} is dps neutral in single target, and could be considered a good movement global if none are available and it would not negatively impact the next use)
  - Maintain {{ site.data.spell.fs }} as many targets as possible, don't forget {{ site.data.talent.pw }} applies one (Do not use {{ site.data.talent.sop }} to spread it!
@@ -581,11 +582,13 @@ Follow the cast sequence below for your opener. A <span style="color:red">red ar
 <br/>
 <br/>
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png" width="130%"/></p>
 
 # Wildfire Builds
 
 Predominately aimed at M+ content these build variants focus on the power of {{ site.data.spell.fs }} and its supporting talents to deal AoE damage, all variants include {{ site.data.talent.dre }} by default as the build spends a lot of its time using the {{ site.data.talent.lvs }} procs it generates so it provides a lot of value on average but is not the focus of the build - if desired you can swap this point to a more consistent option.
+
+<p align="center" style="color:red">Click on a build banner to expand it.</p>
 
 <div class="accordion dungeon-accordion" id="accordion-wildfire">
 <div class="card">
@@ -595,58 +598,58 @@ Predominately aimed at M+ content these build variants focus on the power of {{ 
 <div id="wfaoe-collapse" class="collapse" aria-labelledby="wfaoe" data-parent="#accordion-wildfire">
 <div class="card-body" markdown="1">
 
-# What does this build do?
+## What does this build do?
 
 We heard you like {{ site.data.spell.fs }} and {{ site.data.talent.lvs }} so this build is entirely committed to the idea of maintaining {{ site.data.spell.fs }} on multiple targets and utilizing all the benefits associated with consuming {{ site.data.talent.lvs }}.
 
 Staples of wildfire as a M+ include {{ site.data.talent.sfd }}, {{ site.data.talent.splinter }}, {{ site.data.talent.sk }}. There are more swaps you could make within this archetype like {{ site.data.talent.sop }} swapped for {{ site.data.talent.afs }} which significantly simplifies your perceived gameplay, but in reality is weaker in most ways so all the variants below use {{ site.data.talent.sop }}.
 
-# What does it look like?
+## What does it look like?
 
 There are multiple possible variants of this build that do not include rotational priority changes, these will all play similarly and you can choose between them based on personal preference and/or sim results. The 4 builds linked below are, at least in my opinion, the 'standard' setups with one taking {{ site.data.talent.imp_ftw }} with {{ site.data.talent.potm }}, another opting to go for {{ site.data.talent.flow_of_power }} and {{ site.data.talent.swelling_maelstrom }}, another one playing {{ site.data.talent.searing_flames }} instead of {{ site.data.talent.echo_chamber }} and the last one simply taking {{ site.data.talent.if }} and {{ site.data.talent.electrified_shocks }}.
 
-## Standard build without Elemental Blast
+### Standard build without Elemental Blast
 The standard build for a non-{{ site.data.talent.eb }} build.
 <div class="iframe-holder">
 <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAg0SrIJtkACSjS0SLJOQOAAAAAAgSASJJKpJg0SSaKhgQEgA?width=530&level=70" frameborder="0" width="530px" height="100%"></iframe>
   </div>
 
-## Swelling Maelstrom Variant
+### Swelling Maelstrom Variant
 {{ site.data.talent.swelling_maelstrom }} will give you more room to effectively use your {{ site.data.talent.sop }} and pool Maelstrom.
 <div class="iframe-holder">
 <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAg0Sr0SSLJgQSjS0STCRAAAAAAKBIlkokmASLJppECCRAC?width=530&level=70" frameborder="0" width="530px" height="100%"></iframe>
   </div>
 
-## Searing Flames Variant
+### Searing Flames Variant
 For better overall Maelstrom generation.
 <div class="iframe-holder">
 <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAg0SrIJtkACSjSOQLtkQOAAAAAAgSASJJKpJg0SSaKhgQEgA?width=530&level=70" frameborder="0" width="530px" height="100%"></iframe>
   </div>
 
-## Icefury Variant
+### Icefury Variant
 {{ site.data.talent.if }} gives use some cleave in low target count and flows nicely for Maelstrom generation.
 <div class="iframe-holder">
 <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAg0SrIJtkASLSjS0STiDEAAAAAAKBIlkokmASLJppECCRAC?width=530&level=70" frameborder="0" width="530px" height="100%"></iframe>
-  </div>
+</div>
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-# Stats
+## Stats
 
-## Always remember to sim your current options appropriately
+### Always remember to sim your current options appropriately
  - [Raidbots](https://www.raidbots.com/simbot/topgear)
  - For more information [How Does Elemental Sim?]({{ site.baseurl }}{% link blog/_posts/2023-01-02-simming.md %})  
 
-## Simplified
+### Simplified
 This is quick and dirty, your sims will take priority in your gearing process.
  - Haste / Crit > Mastery / Vers
  - Remember that generally Haste will make the rotation easier to execute and further improve your ability to adapt to movement so will always be a solid stat to go for, and more flexible than Mastery given Haste is also very good in all AoE-focused builds
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+ <p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-# Rotation
+## Rotation
 
-## Key Notes
+### Key Notes
  - If targets will survive for a while you will want {{ site.data.spell.fs }} ticking on them, don't forget to monitor this particularly on higher keys where you can get real value!
  - {{ site.data.talent.lmt }}’s periodic damage scales dynamically with haste, therefore it can be used to setup a pull by applying {{ site.data.spell.fs }} before gaining the {{ site.data.talent.splinter }} haste buff without losing out on too much potential damage. You should still aim to use {{ site.data.talent.lmt }} while having the {{ site.data.talent.splinter }} haste buff or {{ site.data.spell.bl }} if possible, but don't lose setup time for it.
  - {{ site.data.talent.sop }} is there to amplify what you're already aiming to do at different target counts which can be quite handy
@@ -657,7 +660,7 @@ This is quick and dirty, your sims will take priority in your gearing process.
  - {{ site.data.talent.dre }} procs do not really change the priority of what you're doing, they mainly act to provide value from not having to manually refresh your current {{ site.data.spell.fs }} dots and that translates into more {{ site.data.spell.cl }} casts which leads to more {{ site.data.spell.eq }} casts. Note: {{ site.data.spell.lvbm }} replaces {{ site.data.spell.cl }} in the priority when {{ site.data.talent.dre }} procs are active but you should ensure you have enough time to finish the cast inside the {{ site.data.talent.dre }} buff otherwise the cast will cancel.
  - It can be tempting to try and use every {{ site.data.talent.lvs }} proc during mass AoE but generally you're going to use them when you have to move when AoEing or when you'd have enough maelstrom to {{ site.data.spell.eq }} afterwards which benefits from {{ site.data.talent.mote }}. This strikes a better balance between fishing for {{ site.data.talent.dre }} procs and reliably good AoE damage. Feel free to prioritize {{ site.data.talent.lvs }} more if a priority target is up and needs to die fast!
 
-## Opener
+### Opener
 Follow the cast sequence below for your opener. A <span style="color:red">red arrow</span> indicates the time the boss is pulled. Please note that openers are a *very* minor and nit-picky increase (or sometimes decrease!), and adapting to the fight is much more important.
 
 ~3.5 seconds from boss pull
@@ -678,7 +681,7 @@ AoE openers are less rigid than boss openers. Keep in mind that these will chang
    - On pulls that include 6+ targets it is ideal to have {{ site.data.talent.sop }} active for both charges of {{ site.data.talent.sk }} and given the maelstrom generated you can cast {{ site.data.spell.eq }} twice between them, this means that if you do not have maelstrom from a previous pack you may need to hold {{ site.data.talent.sk }} until slightly later in the pull or simply forego this value in favor of using {{ site.data.talent.sk }} without {{ site.data.talent.sop }}.
    - Avoid placing {{ site.data.talent.lmt }} prematurely, if the tank does not have sufficient aggro then its possible for it to be killed directly by mobs which greatly reduces its value
 
-## 1 Target Priority
+### 1 Target Priority
  - {{ site.data.talent.fe }} if it is available and there is no reason to hold its use.
  - {{ site.data.talent.sk }} if you have at least 83 maelstrom (without {{ site.data.talent.potm }} or 80 with {{ site.data.talent.potm }}). This ensures you can buff both charges.
  - {{ site.data.spell.lb }} if both {{ site.data.talent.sk }} and {{ site.data.talent.sop }} buffs are active
@@ -695,7 +698,7 @@ AoE openers are less rigid than boss openers. Keep in mind that these will chang
 
   Note: You do not play around {{ site.data.talent.potm }} procs in single target.
 
-## 2 Targets Priority
+### 2 Targets Priority
  - {{ site.data.talent.fe }} if it is available and there is no reason to hold its use.
  - Maintain {{ site.data.spell.fs }} on both targets at all times, don't forget {{ site.data.talent.pw }} applies one!
  - {{ site.data.talent.sk }} if you have at least 83 maelstrom (without {{ site.data.talent.potm }} or 80 with {{ site.data.talent.potm }}. This ensures you can buff both charges.
@@ -710,7 +713,7 @@ AoE openers are less rigid than boss openers. Keep in mind that these will chang
  - {{ site.data.spell.lvb }}
  - {{ site.data.spell.cl }}
 
-## 3-5 Targets Priority
+### 3-5 Targets Priority
  - {{ site.data.talent.fe }} if it is available and there is no reason to hold its use.
  - Maintain {{ site.data.spell.fs }} on all targets at all times, don't forget {{ site.data.talent.pw }} applies one!
  - {{ site.data.talent.sk }} if it is available and there is no reason to hold its use
@@ -726,7 +729,7 @@ AoE openers are less rigid than boss openers. Keep in mind that these will chang
  - {{ site.data.spell.lvb }}
  - {{ site.data.spell.cl }}
 
-## 6+ Targets Priority
+### 6+ Targets Priority
  - {{ site.data.talent.fe }} if it is available and there is no reason to hold its use.
  - Maintain {{ site.data.spell.fs }} on all targets at all times, don't forget {{ site.data.talent.pw }} applies one!
  - {{ site.data.talent.sk }} if it is available and you have at least enough maelstrom to cast {{ site.data.spell.eq }} after to {{ site.data.talent.sop }} buff the charges!
@@ -752,49 +755,49 @@ AoE openers are less rigid than boss openers. Keep in mind that these will chang
 <div id="wfeb-collapse" class="collapse" aria-labelledby="wfeb" data-parent="#accordion-wildfire">
 <div class="card-body" markdown="1">
 
-# What does this build do?
+## What does this build do?
 
 We heard you like {{ site.data.spell.fs }} and {{ site.data.talent.lvs }} so this build is entirely committed to the idea of maintaining {{ site.data.spell.fs }} on multiple targets and utilizing all the benefits associated with consuming {{ site.data.talent.lvs }}. These variants of Wildfire also include {{ site.data.talent.eb }} for its high power in single target and low target scenarios with relatively minor impact on total AoE value.
 
 Staples of wildfire as a M+ include {{ site.data.talent.sfd }}, {{ site.data.talent.splinter }}, {{ site.data.talent.sk }}. There are more swaps you could make within this archetype like {{ site.data.talent.sop }} swapped for {{ site.data.talent.afs }} which significantly simplifies your perceived gameplay, but in reality is weaker in most ways so all the variants below use {{ site.data.talent.sop }}.
 
-# What does it look like?
+## What does it look like?
 
 There are multiple possible variants of this build that do not include rotational priority changes. They will all play similarly and you can choose between them based on personal preference and/or sim results. The two variants shown above are the common builds that include {{ site.data.talent.eb }} in a Wildfire setup - this is not the only way. The structure is similar to the variants without {{ site.data.talent.eb }} so learning how {{ site.data.talent.eb }} changes the rotation is the only real barrier.
 You might also want to include {{ site.data.talent.ns }} in the class tree if the cast time of {{ site.data.talent.eb }} is a hindrance to you.
 
-## Standard build
+### Standard build
 The standard {{ site.data.dungeon.eb }} build.
 
 <div class="iframe-holder">
 <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAg0SrIJtkAJINKRLtkQOAAAAAAgSASJJKpJg0SSaKhgQEgA?width=530&level=70" frameborder="0" width="530px" height="100%"></iframe>
 </div>
 
-## Icefury Variant
+### Icefury Variant
 {{ site.data.talent.if }} gives use some cleave in low target count and flows nicely for Maelstrom generation.
 
 <div class="iframe-holder">
 <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAg0SrIJtkAJtINKRLNJEAAAAAAKBIlkokmASLJppECCRAC?width=530&level=70" frameborder="0" width="530px" height="100%"></iframe>
 </div>
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-# Stats
+## Stats
 
-## Always remember to sim your current options appropriately
+### Always remember to sim your current options appropriately
  - [Raidbots](https://www.raidbots.com/simbot/topgear)
  - For more information [How Does Elemental Sim?]({{ site.baseurl }}{% link blog/_posts/2023-01-02-simming.md %})  
 
-## Simplified
+### Simplified
 This is quick and dirty, your sims will take priority in your gearing process.
  - Haste / Crit > Mastery / Vers
  - Remember that generally Haste will make the rotation easier to execute and further improve your ability to adapt to movement so will always be a solid stat to go for, and more flexible than Mastery given Haste is also very good in all AoE-focused builds
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+ <p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-# Rotation
+## Rotation
 
-## Key Notes
+### Key Notes
  - If targets will survive for a while you will want {{ site.data.spell.fs }} ticking on them, don't forget to monitor this particularly on higher keys where you can get real value!
  - {{ site.data.talent.lmt }}’s periodic damage scales dynamically with haste, therefore it can be used to setup a pull by applying {{ site.data.spell.fs }} before gaining the {{ site.data.talent.splinter }} haste buff without losing out on too much potential damage. You should still aim to use {{ site.data.talent.lmt }} while having the {{ site.data.talent.splinter }} haste buff or {{ site.data.spell.bl }} if possible, but don't lose setup time for it.
  - {{ site.data.talent.sop }} is there to amplify what you're already aiming to do at different target counts which can be quite handy, whilst it is appreciable that {{ site.data.talent.eb }} reduces the value gained from {{ site.data.talent.sop }} due to being more expensive and producing less buffs overall - this is only true for the 1-4 target range and the value added is still positive, AoE value from {{ site.data.talent.sop }} is unaffected at 6+ targets.
@@ -805,7 +808,7 @@ This is quick and dirty, your sims will take priority in your gearing process.
  - {{ site.data.talent.dre }} procs do not really change the priority of what you're doing, they mainly act to provide value from not having to manually refresh your current {{ site.data.spell.fs }} dots and that translates into more {{ site.data.spell.cl }} casts which leads to more {{ site.data.spell.eq }} casts. Note: {{ site.data.spell.lvbm }} replaces {{ site.data.spell.cl }} in the priority when {{ site.data.talent.dre }} procs are active but you should ensure you have enough time to finish the cast inside the {{ site.data.talent.dre }} buff otherwise the cast will cancel.
  - It can be tempting to try and use every {{ site.data.talent.lvs }} proc during mass AoE but generally you're going to use them when you have to move when AoEing or when you'd have enough maelstrom to {{ site.data.spell.eq }} afterwards which benefits from {{ site.data.talent.mote }}. This strikes a better balance between fishing for {{ site.data.talent.dre }} procs and reliably good AoE damage. Feel free to prioritize {{ site.data.talent.lvs }} more if a priority target is up and needs to die fast!
 
-## Opener
+### Opener
 Follow the cast sequence below for your opener. A <span style="color:red">red arrow</span> indicates the time the boss is pulled. Please note that openers are a *very* minor and nit-picky increase (or sometimes decrease!), and adapting to the fight is much more important.
 
 ~3.5 seconds from boss pull
@@ -826,7 +829,7 @@ AoE openers are less rigid than boss openers. Keep in mind that these will chang
    - On pulls that include 6+ targets it is ideal to have {{ site.data.talent.sop }} active for both charges of {{ site.data.talent.sk }} and given the maelstrom generated you can cast {{ site.data.spell.eq }} twice between them, this means that if you do not have maelstrom from a previous pack you may need to hold {{ site.data.talent.sk }} until slightly later in the pull or simply forego this value in favor of using {{ site.data.talent.sk }} without {{ site.data.talent.sop }}.
    - Avoid placing {{ site.data.talent.lmt }} prematurely, if the tank does not have sufficient aggro then its possible for it to be killed directly by mobs which greatly reduces its value
 
-## 1 Target Priority
+### 1 Target Priority
  - {{ site.data.talent.fe }} if it is available and there is no reason to hold its use.
  - {{ site.data.talent.lmt }} if it is available and no additional targets soon
  - {{ site.data.talent.sk }} if you have at least 75 maelstrom and did not take {{ site.data.talent.swelling_maelstrom }} *or* an active {{ site.data.talent.sop }} buff. This will enable you to buff one of your {{ site.data.talent.sk }} charges.
@@ -845,7 +848,7 @@ AoE openers are less rigid than boss openers. Keep in mind that these will chang
 
   Note: You do not play around {{ site.data.talent.potm }} procs in single target.
 
-## 2 Targets Priority
+### 2 Targets Priority
  - {{ site.data.talent.fe }} if it is available and there is no reason to hold its use.
  - Maintain {{ site.data.spell.fs }} on both targets at all times, don't forget {{ site.data.talent.pw }} applies one!
  - {{ site.data.talent.lmt }} if it is available and no additional targets soon
@@ -862,7 +865,7 @@ AoE openers are less rigid than boss openers. Keep in mind that these will chang
  - {{ site.data.spell.lvb }}
  - {{ site.data.spell.cl }}
 
-## 3 Targets Priority
+### 3 Targets Priority
  - {{ site.data.talent.fe }} if it is available and there is no reason to hold its use.
  - Maintain {{ site.data.spell.fs }} on all targets at all times, don't forget {{ site.data.talent.pw }} applies one!
  - {{ site.data.talent.lmt }} if it is available and no additional targets soon
@@ -878,7 +881,7 @@ AoE openers are less rigid than boss openers. Keep in mind that these will chang
  - {{ site.data.spell.lvb }}
  - {{ site.data.spell.cl }}
 
-## 4 Targets Priority
+### 4 Targets Priority
  - {{ site.data.talent.fe }} if it is available and there is no reason to hold its use.
  - Maintain {{ site.data.spell.fs }} on all targets at all times, don't forget {{ site.data.talent.pw }} applies one!
  - {{ site.data.talent.lmt }} if it is available and no additional targets soon
@@ -910,7 +913,7 @@ AoE openers are less rigid than boss openers. Keep in mind that these will chang
  - {{ site.data.spell.lvb }}
  - {{ site.data.spell.cl }}
 
-## 6+ Targets Priority
+### 6+ Targets Priority
  - {{ site.data.talent.fe }} if it is available and there is no reason to hold its use.
  - Maintain {{ site.data.spell.fs }} on all targets at all times, don't forget {{ site.data.talent.pw }} applies one!
  - {{ site.data.talent.lmt }} if it is available and no additional targets soon
@@ -934,11 +937,13 @@ AoE openers are less rigid than boss openers. Keep in mind that these will chang
 <br/>
 <br/>
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png" width="130%"/></p>
 
 # Lightning Builds
 
 Exactly what it says on the tin, for the friends with a penchant for Lightning! Lightning offers a great way to cater to multiple damage profiles, rarely sacrificing single target for AoE. It also plays differently to the fire builds, placing much more emphasis on {{ site.data.spell.cl }} to generate quickly at high target counts.
+
+<p align="center" style="color:red">Click on a build banner to expand it.</p>
 
 <div class="accordion dungeon-accordion" id="accordion-lightning">
 <div class="card">
@@ -948,11 +953,11 @@ Exactly what it says on the tin, for the friends with a penchant for Lightning! 
 <div id="limwf-collapse" class="collapse" aria-labelledby="limwf" data-parent="#accordion-lightning">
 <div class="card-body" markdown="1">
 
-# What does this build do?
+## What does this build do?
 
 This build focuses on the power of {{ site.data.spell.lb }}, {{ site.data.spell.cl }} and {{ site.data.talent.eb }} with {{ site.data.talent.eogs }}. It seeks to empower these effects with supporting talents like {{ site.data.talent.e_shocks }}, {{ site.data.talent.se }}, and {{ site.data.talent.lr }}. This build will be for you if you are not a fan of {{ site.data.spell.fs }} dot management or random effects that can swing your damage like {{ site.data.talent.dre }}, effectively being a solid and consistent way of dealing damage that is flexible to all target counts - the more targets the better!
 
-# What does it look like?
+## What does it look like?
 <div class="iframe-holder">
 <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAoVSSLJSJJtENE0QiEAAAAAgSASJJKpJg0SSaKhgQEgA?width=530&level=70" frameborder="0" width="530px" height="100%"></iframe>
   </div>
@@ -963,24 +968,24 @@ Note:
   - {{ site.data.talent.lmt }} is preferred over {{ site.data.spell.tempest }} (gained via {{ site.data.talent.pe }}) because of its overall value being far higher over the course of a key, {{ site.data.talent.pe }} is only preferable on single target.
   - You may substitute {{ site.data.talent.sop }} for {{ site.data.talent.afs }} for comfort but it is substantially worse on single target (which is still relevant on bosses in M+!) and worse on 6+ (reliability is key, the gap alters as you add more targets in favor of {{ site.data.talent.afs }}. If you make this substitution simply ignore any line that shows {{ site.data.talent.sop }}; {{ site.data.talent.afs }} has no impact upon priority!
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-# Stats
+## Stats
 
-## Always remember to sim your current options appropriately
+### Always remember to sim your current options appropriately
  - [Raidbots](https://www.raidbots.com/simbot/topgear)
  - For more information [How Does Elemental Sim?]({{ site.baseurl }}{% link blog/_posts/2023-01-02-simming.md %})  
 
-## Simplified
+### Simplified
 This is quick and dirty, your sims will take priority in your gearing process.
  - Haste / Crit > Mastery / Vers
  - Remember that generally Haste will make the rotation easier to execute and further improve your ability to adapt to movement so will always be a solid stat to go for, and more flexible than Mastery given Haste is also very good in all AoE-focused builds
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-# Rotation
+## Rotation
 
-## Key Notes
+### Key Notes
  - {{ site.data.talent.mote }} is mainly to path to {{ site.data.talent.lmt }}, once you hit 3 targets any sort of gaming the {{ site.data.talent.mote }} buff becomes extremely bad, in practice this also makes the points spent in {{ site.data.talent.potm }} near worthless however they are also needed for {{ site.data.talent.echo_chamber }} & {{ site.data.talent.mwf }}
  - {{ site.data.talent.lr }} applies to your current target when it does not have an active buff. {{ site.data.spell.eq }} has *some* 'smart' applications to apply to off-targets but results can vary. It is suggested *when you are comfortable enough to do so* to incorporate target swapping after each spender to increase the value gained from {{ site.data.talent.lr }}. If done poorly (i.e. too early in the learning process) this can produce negative results, master the basics then add complexity!
  - {{ site.data.talent.lmt }} is included for its raw damage, don't start to spread {{ site.data.spell.fs }} unless you have to move - in which case it remains a good movement global when {{ site.data.talent.if }} buffed {{ site.data.spell.frs }} aren't available.
@@ -990,7 +995,7 @@ This is quick and dirty, your sims will take priority in your gearing process.
     * 6+ Targets = {{ site.data.spell.cl }} whenever possible
     * {{ site.data.talent.sop }} will also make you want to delay casting {{ site.data.talent.sk }} on 1-2 targets or 6+ targets in order to benefit from their combined effects.
 
-## Opener
+### Opener
 Follow the cast sequence below for your opener. A <span style="color:red">red arrow</span> indicates the time the boss is pulled. Please note that openers are a *very* minor and nit-picky increase (or sometimes decrease!), and adapting to the fight is much more important.
 
 ~3.5 seconds from boss pull
@@ -1011,7 +1016,7 @@ AoE openers are less rigid than boss openers. Keep in mind that these will chang
    - On pulls that include 6+ targets it is ideal to have {{ site.data.talent.sop }} active for both charges of {{ site.data.talent.sk }} and given the maelstrom generated you can cast {{ site.data.spell.eq }} twice between them, this means that if you do not have maelstrom from a previous pack you may need to hold {{ site.data.talent.sk }} until slightly later in the pull or simply forego this value in favor of using {{ site.data.talent.sk }} without {{ site.data.talent.sop }}.
    - Avoid placing {{ site.data.talent.lmt }} prematurely, if the tank does not have sufficient aggro then its possible for it to be killed directly by mobs which greatly reduces its value
 
-## 1 Target Priority
+### 1 Target Priority
  - {{ site.data.talent.se }} if it is available and there is no reason to hold its use.
  - {{ site.data.talent.lmt }} if it is available and no additional targets soon. (using {{ site.data.talent.totemic_recall }} is dps neutral in single target, and could be considered a good movement global if none are available and it would not negatively impact the next use)
  - {{ site.data.spell.fs }} if the debuff has faded or will in ~5 seconds
@@ -1028,7 +1033,7 @@ AoE openers are less rigid than boss openers. Keep in mind that these will chang
  - You do not play around {{ site.data.talent.potm }} procs in single target.
  - You do not play around {{ site.data.talent.eogs }} buffs in single target.
 
-## 2 Targets Priority
+### 2 Targets Priority
  - {{ site.data.talent.se }} if it is available and there is no reason to hold its use.
  - {{ site.data.talent.lmt }} if it is available and no additional targets soon.
  - {{ site.data.talent.sk }} if you have at least 125 maelstrom with {{ site.data.talent.swelling_maelstrom }} *or* an active {{ site.data.talent.sop }} buff and at least 46 maelstrom. This will enable you to buff both of your {{ site.data.talent.sk }} charges if you cast {{ site.data.spell.lvb }} before your second {{ site.data.talent.eb }} cast.
@@ -1046,7 +1051,7 @@ AoE openers are less rigid than boss openers. Keep in mind that these will chang
   Note:
  - Playing around {{ site.data.talent.potm }} procs is dps neutral, but generally it will be easier and less likely to negatively impact your performance if you ignore them - sometimes you will get lucky and have one during your {{ site.data.talent.sk }} burst though!
 
-## 3 Targets Priority
+### 3 Targets Priority
  - {{ site.data.talent.se }} if it is available and there is no reason to hold its use.
  - {{ site.data.talent.lmt }} if it is available and no additional targets soon.
  - {{ site.data.talent.sk }} if it is available and no additional targets soon.
@@ -1064,7 +1069,7 @@ AoE openers are less rigid than boss openers. Keep in mind that these will chang
  - {{ site.data.talent.eb }} if {{ site.data.talent.eogs }} buff is not active
  - {{ site.data.spell.cl }}
 
-## 6+ Targets Priority
+### 6+ Targets Priority
  - {{ site.data.talent.se }} if it is available and there is no reason to hold its use.
  - {{ site.data.talent.lmt }} if it is available and no additional targets soon.
  - {{ site.data.talent.sk }} if you have 50 maelstrom and {{ site.data.talent.eogs }} buff is active *or* 75 maelstrom and {{ site.data.talent.eogs }} is not active
@@ -1086,11 +1091,11 @@ AoE openers are less rigid than boss openers. Keep in mind that these will chang
 <div id="lisfd-collapse" class="collapse" aria-labelledby="lisfd" data-parent="#accordion-lightning">
 <div class="card-body" markdown="1">
 
-# What does this build do?
+## What does this build do?
 
 This build focuses on the power of {{ site.data.spell.lb }}, {{ site.data.spell.cl }} and {{ site.data.talent.eb }} with {{ site.data.talent.eogs }}. It seeks to empower these effects with supporting talents like {{ site.data.talent.e_shocks }}, {{ site.data.talent.se }}, and {{ site.data.talent.lr }}. This variant of Lightning includes {{ site.data.talent.sfd }} to further empower your {{ site.data.talent.lmt }} per-use value in addition to increasing the uptime of {{ site.data.talent.se }} which gets more relevant when pulling high target counts as the majority of your time is spent pressing {{ site.data.spell.cl }} when you hit 5 or more targets. This means that movement globals or {{ site.data.talent.sop }} buffs between 3-5 targets can be very beneficial despite {{ site.data.spell.fs }} not being the main focus.
 
-# What does it look like?
+## What does it look like?
 <div class="iframe-holder">
 <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAoVSSLJJlk0S0Q0SD4ABAAAAAoEgUSiSaCItkkmSIIEBI?width=530&level=70" frameborder="0" width="530px" height="100%"></iframe>
   </div>
@@ -1101,24 +1106,25 @@ Note:
  - {{ site.data.talent.lmt }} is preferred over {{ site.data.spell.tempest }} (gained via {{ site.data.talent.pe }}) because of its overall value being far higher over the course of a key, {{ site.data.talent.pe }} is only preferable on single target. Whilst this build does utilize more {{ site.data.spell.fs }} than other Lightning variants it will generally not be worthwhile to run {{ site.data.talent.pe }} simply because it is opportunity costed against {{ site.data.talent.lmt }}.
  - You may substitute {{ site.data.talent.sop }} for {{ site.data.talent.afs }} for comfort but it is substantially worse on single target (which is still relevant on bosses in M+!) and worse on 6+ (reliability is key, the gap alters as you add more targets in favor of {{ site.data.talent.afs }}. If you make this substitution simply ignore any line that shows {{ site.data.talent.sop }}; {{ site.data.talent.afs }} has no impact upon priority!
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-# Stats
+## Stats
 
-## Always remember to sim your current options appropriately
+### Always remember to sim your current options appropriately
  - [Raidbots](https://www.raidbots.com/simbot/topgear)
  - For more information [How Does Elemental Sim?]({{ site.baseurl }}{% link blog/_posts/2023-01-02-simming.md %})
 
-## Simplified
+### Simplified
 This is quick and dirty, your sims will take priority in your gearing process.
  - Haste / Crit > Mastery / Vers
  - Remember that generally Haste will make the rotation easier to execute and further improve your ability to adapt to movement so will always be a solid stat to go for, and more flexible than Mastery given Haste is also very good in all AoE-focused builds
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-# Rotation
 
-## Key Notes
+## Rotation
+
+### Key Notes
  - {{ site.data.talent.mote }} is mainly to path to {{ site.data.talent.lmt }}, once you hit 3 targets any sort of gaming the {{ site.data.talent.mote }} buff becomes extremely bad.
  - {{ site.data.talent.lr }} applies to your current target when it does not have an active buff. {{ site.data.spell.eq }} has *some* 'smart' applications to apply to off-targets but results can vary. It is suggested *when you are comfortable enough to do so* to incorporate target swapping after each spender to increase the value gained from {{ site.data.talent.lr }}. If done poorly (i.e. too early in the learning process) this can produce negative results, master the basics then add complexity!
  - {{ site.data.talent.lmt }} is included for its raw damage, don't start to spread {{ site.data.spell.fs }} unless you have to move - in which case it remains a good movement global when {{ site.data.talent.if }} buffed {{ site.data.spell.frs }} aren't available.
@@ -1128,7 +1134,7 @@ This is quick and dirty, your sims will take priority in your gearing process.
     * 6+ Targets = {{ site.data.spell.cl }} whenever possible
     * {{ site.data.talent.sop }} will also make you want to delay casting {{ site.data.talent.sk }} on 1-2 targets or 6+ targets in order to benefit from their combined effects.
 
-## Opener
+### Opener
 Follow the cast sequence below for your opener. A <span style="color:red">red arrow</span> indicates the time the boss is pulled. Please note that openers are a *very* minor and nit-picky increase (or sometimes decrease!), and adapting to the fight is much more important.
 
 ~3.5 seconds from boss pull
@@ -1149,7 +1155,7 @@ AoE openers are less rigid than boss openers. Keep in mind that these will chang
    - On pulls that include 6+ targets it is ideal to have {{ site.data.talent.sop }} active for both charges of {{ site.data.talent.sk }} and given the maelstrom generated you can cast {{ site.data.spell.eq }} twice between them, this means that if you do not have maelstrom from a previous pack you may need to hold {{ site.data.talent.sk }} until slightly later in the pull or simply forego this value in favor of using {{ site.data.talent.sk }} without {{ site.data.talent.sop }}.
    - Avoid placing {{ site.data.talent.lmt }} prematurely, if the tank does not have sufficient aggro then its possible for it to be killed directly by mobs which greatly reduces its value
 
-## 1 Target Priority
+### 1 Target Priority
  - {{ site.data.talent.se }} if it is available and there is no reason to hold its use.
  - {{ site.data.talent.lmt }} if it is available and no additional targets soon. (using {{ site.data.talent.totemic_recall }} is dps neutral in single target, and could be considered a good movement global if none are available and it would not negatively impact the next use)
  - {{ site.data.talent.sk }} if you have at least 124 maelstrom with {{ site.data.talent.swelling_maelstrom }} *or* an active {{ site.data.talent.sop }} buff and at least 46 maelstrom. This will enable you to buff both of your {{ site.data.talent.sk }} charges if you cast {{ site.data.spell.lvb }} before your second {{ site.data.talent.eb }} cast.
@@ -1166,7 +1172,7 @@ AoE openers are less rigid than boss openers. Keep in mind that these will chang
  - You do not play around {{ site.data.talent.potm }} procs in single target.
  - You do not play around {{ site.data.talent.eogs }} buffs in single target.
 
-## 2 Targets Priority
+### 2 Targets Priority
  - {{ site.data.talent.se }} if it is available and there is no reason to hold its use.
  - {{ site.data.talent.lmt }} if it is available and no additional targets soon.
  - {{ site.data.talent.sk }} if you have at least 125 maelstrom with {{ site.data.talent.swelling_maelstrom }} *or* an active {{ site.data.talent.sop }} buff and at least 46 maelstrom. This will enable you to buff both of your {{ site.data.talent.sk }} charges if you cast {{ site.data.spell.lvb }} before your second {{ site.data.talent.eb }} cast.
@@ -1184,7 +1190,7 @@ AoE openers are less rigid than boss openers. Keep in mind that these will chang
   Note:
  - Playing around {{ site.data.talent.potm }} procs is dps neutral, but generally it will be easier and less likely to negatively impact your performance if you ignore them - sometimes you will get lucky and have one during your {{ site.data.talent.sk }} burst though!
 
-## 3 Targets Priority
+### 3 Targets Priority
  - {{ site.data.talent.se }} if it is available and there is no reason to hold its use.
  - {{ site.data.talent.lmt }} if it is available and no additional targets soon.
  - {{ site.data.talent.sk }} if it is available and no additional targets soon.
@@ -1210,7 +1216,7 @@ AoE openers are less rigid than boss openers. Keep in mind that these will chang
   Note:
  - {{ site.data.talent.if }} becomes a dps loss at 4 or more targets, you can use it when you know movement will be needed and it serves as a reduction in loss incurred by movement. Try to utilize {{ site.data.talent.swg }} where possible.
 
-## 6+ Targets Priority
+### 6+ Targets Priority
  - {{ site.data.talent.se }} if it is available and there is no reason to hold its use.
  - {{ site.data.talent.lmt }} if it is available and no additional targets soon.
  - {{ site.data.talent.sk }} if you have 50 maelstrom and {{ site.data.talent.eogs }} buff is active *or* 75 maelstrom and {{ site.data.talent.eogs }} is not active

--- a/guide/general/builds.md
+++ b/guide/general/builds.md
@@ -12,7 +12,7 @@ big_article: true
 This page aims to display and discuss the recommended and most widely-used Builds available to Elemental. This is not an exhaustive list of all options and *does not imply that any build **not** shown here is automatically terrible/unplayable*.  
 In practical terms we cannot account for every build variation and effort has been largely focused on the highest performing / most popular builds. If you find something that you feel works or performs better than what is listed here feel free to contact the team on [Storm, Earth & Lava Discord](https://discord.gg/y5dUf3PWrU) or [Earthshrine #Elemental Channel](https://discord.gg/earthshrine)
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png" width="130%"/></p>
+<hr>
 
 # Class Tree
 
@@ -46,7 +46,7 @@ More situational talents picks:
   - {{ site.data.talent.purge }} and {{ site.data.talent.cleanse_spirit }} are perfect examples of good talents that are purely situational and can be skipped in many builds, and picked only when needed.
   - {{ site.data.talent.capacitor_totem }}, {{ site.data.talent.hex }}, {{ site.data.talent.earthgrab_totem }} or {{ site.data.talent.thunderstorm }} are situational Crowd Control talents.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png" width="130%"/></p>
+<hr>
 
 # Hotfixes applied on 28/02/23 (NA) and 01/03/23 (EU):
 First and foremost, they do not appear to have any impact on rotational priority from initial testing. This includes but is not limited to:
@@ -55,7 +55,7 @@ First and foremost, they do not appear to have any impact on rotational priority
    - For those using {{ site.data.talent.mwf }} builds remember the priority has not changed, the build just has less sources of {{ site.data.talent.lvs }} procs relative to the alternative {{ site.data.talent.wlr }} build.
    - Some players were already including {{ site.data.talent.icefury }} with {{ site.data.talent.e_shocks }} into the Wildfire builds (trading {{ site.data.talent.fop }} for them), this choice gained some ground with the buff to baseline {{ site.data.spell.frs }} damage and the maelstrom gains of {{ site.data.talent.if }} buffs.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png" width="130%"/></p>
+<hr>
 
 # Primordial Surge Builds
 
@@ -90,7 +90,7 @@ As the name suggests this is predominately aimed at single target but due to tak
   <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAgUSr0SCAJlkUoEl0SCRAAAAAAKBIlkgmASLJppECSkEgA?width=530&level=70" frameborder="0" width="530px" height="100%"></iframe>
 </div>
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ## Stats
 
@@ -103,7 +103,7 @@ This is quick and dirty, your sims will take priority in your gearing process.
  - Mastery / Haste >> Versatility = Crit
  - Remember that generally Haste will make the rotation easier to execute and further improve your ability to adapt to movement so will always be a solid stat to go for, and more flexible than Mastery given Haste is also very good in all AoE-focused builds
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ## Rotation
 
@@ -211,7 +211,7 @@ As this build takes {{ site.data.talent.dre }} and extends to {{ site.data.talen
   <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAgUSr0SCAJlkUSKBtkQEAAAAAgSASJJoJg0SSaKhgEJBI?width=530&level=70" frameborder="0" width="530px" height="100%"></iframe>
 </div>
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ## Stats
 
@@ -224,7 +224,7 @@ This is quick and dirty, your sims will take priority in your gearing process.
  - Haste >> Mastery > Versatility = Crit
  - Remember that generally Haste will make the rotation easier to execute and further improve your ability to adapt to movement so will always be a solid stat to go for, and more flexible than Mastery given Haste is also very good in all AoE-focused builds
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ## Rotation
 
@@ -339,7 +339,7 @@ This build effectively swaps {{ site.data.talent.wlr }} or {{ site.data.talent.f
   <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAgUSr0SCAJlkUoE0SSSEAAAAAgSASJJoJg0SSaKhgEJBI?width=530&level=70" frameborder="0" width="530px" height="100%"></iframe>
 </div>
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ## Stats
 
@@ -352,7 +352,7 @@ This is quick and dirty, your sims will take priority in your gearing process.
  - Haste / Mastery > Versatility = Crit
  - Remember that generally Haste will make the rotation easier to execute and further improve your ability to adapt to movement so will always be a solid stat to go for, and more flexible than Mastery given Haste is also very good in all AoE-focused builds
 
- <p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+ <hr>
 
 ## Rotation
 
@@ -454,7 +454,7 @@ This build can be harder to play effectively as it requires you to play around b
 <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAgUSrIJtkEkg0oE0kkkDAAAAAAoEgUSCaCItkkmSIIRSAC?width=530&level=70" frameborder="0" width="530px" height="100%"></iframe>
   </div>
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ## Stats
 
@@ -468,7 +468,7 @@ This is quick and dirty, your sims will take priority in your gearing process.
  - Remember that generally Haste will make the rotation easier to execute and further improve your ability to adapt to movement so will always be a solid stat to go for, and more flexible than Mastery given Haste is also very good in all AoE-focused builds
  - Mastery has very good synergy with both {{ site.data.talent.mwf }} and {{ site.data.spell.lvb }}.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ## Rotation
 
@@ -582,7 +582,7 @@ Follow the cast sequence below for your opener. A <span style="color:red">red ar
 <br/>
 <br/>
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png" width="130%"/></p>
+<hr>
 
 # Wildfire Builds
 
@@ -632,7 +632,7 @@ For better overall Maelstrom generation.
 <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAg0SrIJtkASLSjS0STiDEAAAAAAKBIlkokmASLJppECCRAC?width=530&level=70" frameborder="0" width="530px" height="100%"></iframe>
 </div>
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ## Stats
 
@@ -645,7 +645,7 @@ This is quick and dirty, your sims will take priority in your gearing process.
  - Haste / Crit > Mastery / Vers
  - Remember that generally Haste will make the rotation easier to execute and further improve your ability to adapt to movement so will always be a solid stat to go for, and more flexible than Mastery given Haste is also very good in all AoE-focused builds
 
- <p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+ <hr>
 
 ## Rotation
 
@@ -780,7 +780,7 @@ The standard {{ site.data.dungeon.eb }} build.
 <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAg0SrIJtkAJtINKRLNJEAAAAAAKBIlkokmASLJppECCRAC?width=530&level=70" frameborder="0" width="530px" height="100%"></iframe>
 </div>
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ## Stats
 
@@ -793,7 +793,7 @@ This is quick and dirty, your sims will take priority in your gearing process.
  - Haste / Crit > Mastery / Vers
  - Remember that generally Haste will make the rotation easier to execute and further improve your ability to adapt to movement so will always be a solid stat to go for, and more flexible than Mastery given Haste is also very good in all AoE-focused builds
 
- <p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+ <hr>
 
 ## Rotation
 
@@ -937,7 +937,7 @@ AoE openers are less rigid than boss openers. Keep in mind that these will chang
 <br/>
 <br/>
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png" width="130%"/></p>
+<hr>
 
 # Lightning Builds
 
@@ -968,7 +968,7 @@ Note:
   - {{ site.data.talent.lmt }} is preferred over {{ site.data.spell.tempest }} (gained via {{ site.data.talent.pe }}) because of its overall value being far higher over the course of a key, {{ site.data.talent.pe }} is only preferable on single target.
   - You may substitute {{ site.data.talent.sop }} for {{ site.data.talent.afs }} for comfort but it is substantially worse on single target (which is still relevant on bosses in M+!) and worse on 6+ (reliability is key, the gap alters as you add more targets in favor of {{ site.data.talent.afs }}. If you make this substitution simply ignore any line that shows {{ site.data.talent.sop }}; {{ site.data.talent.afs }} has no impact upon priority!
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ## Stats
 
@@ -981,7 +981,7 @@ This is quick and dirty, your sims will take priority in your gearing process.
  - Haste / Crit > Mastery / Vers
  - Remember that generally Haste will make the rotation easier to execute and further improve your ability to adapt to movement so will always be a solid stat to go for, and more flexible than Mastery given Haste is also very good in all AoE-focused builds
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ## Rotation
 
@@ -1106,7 +1106,7 @@ Note:
  - {{ site.data.talent.lmt }} is preferred over {{ site.data.spell.tempest }} (gained via {{ site.data.talent.pe }}) because of its overall value being far higher over the course of a key, {{ site.data.talent.pe }} is only preferable on single target. Whilst this build does utilize more {{ site.data.spell.fs }} than other Lightning variants it will generally not be worthwhile to run {{ site.data.talent.pe }} simply because it is opportunity costed against {{ site.data.talent.lmt }}.
  - You may substitute {{ site.data.talent.sop }} for {{ site.data.talent.afs }} for comfort but it is substantially worse on single target (which is still relevant on bosses in M+!) and worse on 6+ (reliability is key, the gap alters as you add more targets in favor of {{ site.data.talent.afs }}. If you make this substitution simply ignore any line that shows {{ site.data.talent.sop }}; {{ site.data.talent.afs }} has no impact upon priority!
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ## Stats
 
@@ -1119,7 +1119,7 @@ This is quick and dirty, your sims will take priority in your gearing process.
  - Haste / Crit > Mastery / Vers
  - Remember that generally Haste will make the rotation easier to execute and further improve your ability to adapt to movement so will always be a solid stat to go for, and more flexible than Mastery given Haste is also very good in all AoE-focused builds
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 
 ## Rotation

--- a/guide/general/consumables.md
+++ b/guide/general/consumables.md
@@ -1,22 +1,22 @@
 ---
 layout: page
 title: Consumables
-last_update: 13/12/22
-game_version: 10.0.2 Dragonflight
+last_update: 29/03/2023
+game_version: 10.0.7 Dragonflight
 toc: true
+big_article: false
 ---
 
 ## Phial
-### Raid
-1. {{ site.data.item.phial_ci }} If you can stand alone for the majority of combat time this is great.
-1. {{ site.data.item.phial_se }} If you can manage your movement well, or there isn't much movement, this is great.
-1. {{ site.data.item.phial_tv }} and {{ site.data.item.phial_ec }} have less potential power than the previous two Phials however provide similar value to each other and in a straight-forward manner. 
+* **Raid**
+  1. {{ site.data.item.phial_ci }} would be the best phial in raid if you could stand still for the majority of the fight. However, it is a very difficult to keep uptime in most raid encounters.
+  1. {{ site.data.item.phial_tv }} is the best realistic pick in raid. {{ site.data.item.phial_tv }} also boosts our survivability by a non-negligible amount.
 
-### Mythic+
-1. {{ site.data.item.phial_gf }} 
+* **Mythic+**
+  * {{ site.data.item.phial_tv }} is the best phial for mythic +, providing a higher damage gain than {{ site.data.item.phial_gf }} and helping you with survivability as well.
 
 ## Food
-1. {{ site.data.item.food_feast_kaluak }} or {{ site.data.item.food_feast_draconic }}
+1. {{ site.data.item.food_feast_kaluak }} or {{ site.data.item.food_feast_draconic }}.
 1. {{ site.data.item.food_ffc }}
 
 ## Damage Potion
@@ -25,7 +25,17 @@ toc: true
 1. {{ site.data.item.potion_bp }} and {{ site.data.item.potion_sd }} may be considered in specific circumstances that suit them, use your best judgement!
 
 ## Health Potion
-1. {{ site.data.item.potion_rhp }}
+* {{ site.data.item.potion_rhp }} will be the best choice.
+
+## Rune
+* {{ site.data.item.rune_haste }} when you do not use {{ site.data.talent.imp_ftw }}.
+
+## Gems
+Sim for your best stat where choices are available.
+1. Make sure to have an Illimited Gem, i.e. {{ site.data.item.gem_p_haste }}, equipped.
+1. For AoE focus {{ site.data.item.gem_haste_crit }} / {{ site.data.item.gem_crit_haste }}.
+1. For Raid single target focus {{ site.data.item.gem_mast }} / {{ site.data.item.gem_haste_mast }}.
+1. **Do not overthink your gems.** Yes they have an impact on performances. But ultimately, the overall effect they have is minor compared to your gameplay. As long as you socket appropriately to your personal goals and content, you will be fine!
 
 ## Enchants
 
@@ -37,17 +47,7 @@ Chest | {{ site.data.item.ench_chest_stats }} | {{ site.data.item.eternal_insigh
 Legs | {{ site.data.item.spellthread }} | {{ site.data.item.spellthread_lower }}
 Rings | {{ site.data.item.ench_ring_haste }} * | {{ site.data.item.ench_ring_haste_low }} *
 Bracers | {{ site.data.item.ench_wri_av }} or {{ site.data.item.ench_wri_le }} or {{ site.data.item.ench_wri_sp }} | {{ site.data.item.ench_wri_av_low }} or {{ site.data.item.ench_wri_le_low }} or {{ site.data.item.ench_wri_sp_low }}
-Boots | {{ site.data.item.ench_boots_stam }} or {{ site.data.item.ench_boots_sp }} | N/A 
+Boots | {{ site.data.item.ench_boots_stam }} or {{ site.data.item.ench_boots_sp }} | N/A
 
 Note: In addition to the Affordable Alternatives listed here, remember that prices will vary based on the consumable Quality also - use your best judgement!
 - Ring enchants can be optimised using Raidbots sims if desired, Haste is recommended here for its consistent value across most builds and content types.
-
-## Rune
-- {{ site.data.item.rune_haste }}
-
-## Gems
-Sim for your best stat where choices are available.
-1. Make sure to have an Illimited Gem i.e. {{ site.data.item.gem_p_haste }} equipped.
-1. For AoE focus {{ site.data.item.gem_haste_crit }} / {{ site.data.item.gem_crit_haste }}
-1. For Raid single target focus {{ site.data.item.gem_mast }}
-1. Do not overthink your gems, yes they have an impact on performance but ultimately the overall effect they have is minor compared to your gameplay - as long as you socket appropriate to your personal goals and content you will be fine! 

--- a/guide/general/faq.md
+++ b/guide/general/faq.md
@@ -1,71 +1,71 @@
 ---
 layout: page
 title: F.A.Q.
-last_update: 14/03/2023
-game_version: 10.0.5 Dragonflight
+last_update: 29/03/2023
+game_version: 10.0.7 Dragonflight
 toc: true
+big_article: false
 ---
 
 This page has the answers to some frequently asked questions for Elemental Shamans.
 
-### Q: "Will Elemental be viable in Dragonflight 10.0.5?"
-Firstly, no spec in the game is unviable. Certain specs may be favoured for certain bosses in a raid, but this is only relevant to the very highest end of raiding (ie, competing for world first). Elemental (and every other spec) will remain competitive for 99.9% of the playerbase.
+### Q: "Will Elemental be viable in Dragonflight 10.0.7?"
+* Firstly, no spec in the game is unviable. Certain specs may be favored for certain bosses in a raid, but this is only relevant to the very highest end of raiding (ie, competing for world first). Elemental (and every other spec) will remain competitive for 99.9% of the player base.
 
 ### Q: "What do all these abbreviations mean? I can't understand other Elemental Shaman!"
-It can be tough trying to learn all of them at once but there is a handy resource to help you! [Elemental Abbreviations]({{ site.baseurl }}{% link blog/_posts/2023-01-23-ele101.md %}).
+* It can be tough trying to learn all of them at once but there is a handy resource to help you! [Elemental Abbreviations]({{ site.baseurl }}{% link blog/_posts/2023-01-23-ele101.md %}).
 
 ### Q: "What does {{ site.data.talent.fol }} actually reduce?"
-For a complete list, see [Flash of Lightning]({{ site.baseurl }}{%link blog/_posts/2023-01-23-fol.md %}).
+* For a complete list, see [Flash of Lightning]({{ site.baseurl }}{%link blog/_posts/2023-01-23-fol.md %}).
 
 ### Q: "Is there a point where I don't cast {{site.data.spell.es}} with {{site.data.talent.eogs}} talented?"
-**No**, unless you have {{ site.data.talent.eb }} talented this part of the rotation remains the same as Shadowlands: always alternate!
+* **No**, unless you have {{ site.data.talent.eb }} talented this part of the rotation remains the same as Shadowlands: always alternate!
 
 ### Q: "Okay, so what about {{ site.data.talent.eb }} and/or {{ site.data.talent.eogs }} then?!"
-**Yes**, these talent choices do impact your spender use
+* **Yes**, these talent choices do impact your spender use
    - If you have taken {{ site.data.talent.eb }} and *not* {{ site.data.talent.eogs }} then you will use {{ site.data.talent.eb }} instead of {{ site.data.spell.eq }} until 4 targets are present.
    - If you have taken {{ site.data.talent.eb }} *and* {{ site.data.talent.eogs }} then you will ignore {{ site.data.talent.eogs }}'s effect until 2 targets are present.
 
-### Q: "What Pots/Food/Flasks should I use?"
-See the [Consumables]({{ site.baseurl }}{% link guide/general/consumables.md %}) section of the guide.
+### Q: "What Pots/Food/Phials should I use?"
+* See the [Consumables]({{ site.baseurl }}{% link guide/general/consumables.md %}) section of the guide.
 
 ### Q: "How many targets should I cast {{ site.data.spell.fs }} on?"
-See the Priority List for each build in the [Build]({{ site.baseurl }}{% link guide/general/builds.md %}) section of the guide.
+* See the Priority List for each build in the [Build]({{ site.baseurl }}{% link guide/general/builds.md %}) section of the guide.
 
 ### Q: "When do I cast {{ site.data.spell.cl }}?"
-{{ site.data.spell.cl }} replaces {{ site.data.spell.lb }} as a filler from 2 or more targets.
+* {{ site.data.spell.cl }} replaces {{ site.data.spell.lb }} as a filler from 2 or more targets.
 
 ### Q: "What about with {{ site.data.talent.sk }}?"
-With {{ site.data.talent.sop }} talented:
-- 1-2 targets = {{ site.data.spell.lb }} with {{ site.data.talent.sop }} buff active.
-- 3-5 targets = {{ site.data.spell.cl }} or {{ site.data.spell.lvbm }} with {{ site.data.talent.mote }} buff active.
-- 6+ targets = {{ site.data.spell.cl }} or {{ site.data.spell.lvbm }} with {{ site.data.talent.sop }} buff active.
-
-Without {{ site.data.talent.sop }}:
-- 1 target = {{ site.data.spell.lb }} with {{ site.data.talent.mote }} buff active.
-- 2+ targets {{ site.data.spell.cl }} or {{ site.data.spell.lvbm }} with {{ site.data.talent.mote }} buff active.
+* With {{ site.data.talent.sop }} talented:
+  - 1-2 targets = {{ site.data.spell.lb }} with {{ site.data.talent.sop }} buff active.
+  - 3-5 targets = {{ site.data.spell.cl }} or {{ site.data.spell.lvbm }} with {{ site.data.talent.mote }} buff active.
+  - 6+ targets = {{ site.data.spell.cl }} or {{ site.data.spell.lvbm }} with {{ site.data.talent.sop }} buff active.
+* Without {{ site.data.talent.sop }}:
+  - 1 target = {{ site.data.spell.lb }} with {{ site.data.talent.mote }} buff active.
+  - 2+ targets {{ site.data.spell.cl }} or {{ site.data.spell.lvbm }} with {{ site.data.talent.mote }} buff active.
 
 ### Q: "Does {{ site.data.spell.eq }} stack?"
-Yes, {{ site.data.spell.eq }} stacks and has no stack limit.
+* Yes, {{ site.data.spell.eq }} stacks and has no stack limit. Also Haste doesn't affect its tick rate.
 
 ### Q: "When should I stop using {{ site.data.spell.es }} and use {{ site.data.spell.eq }}?"
-In general, stop using {{ site.data.spell.es }} against two targets or more. But check out the [Priority List]({{ site.baseurl }}{% link guide/general/priority_list.md %}) page for more information.
+* In general, stop using {{ site.data.spell.es }} against two targets or more. But check out the [Priority List]({{ site.baseurl }}{% link guide/general/priority_list.md %}) page for more information.
 
 ### Q: "When is the best time to use Primal Fire Elemental's {{ site.data.spell.meteor }} and Primal Storm Elemental's {{ site.data.spell.tempest }}?"
-When they would hit the most targets. For {{ site.data.spell.tempest }} specifically, you need to ensure it is also fully buffed by {{ site.data.spell.call_lightning }}.  
+* When they would hit the most targets. For {{ site.data.spell.tempest }} specifically, you need to ensure it is also fully buffed by {{ site.data.spell.call_lightning }}.  
 *Note: This only applies when talented into {{ site.data.talent.pe }}. Both abilities can be macro'd. See useful macros further down.*
 
-### Q: "Is there a way to enable/disable Earth Elemental taunt without screwing up my autocast settings of the DPS Elemental?"
-Not that we're aware of. The Elementals' autocast settings are shared between the Elemental pets. If you deactivate or activate it on one button, the matching button of the other Elementals will share that setting. We hope that this will be changed.  
+### Q: "Is there a way to enable/disable {{ site.data.talent.ee }} taunt without screwing up my autocast settings of the DPS Elemental?"
+* Not that we're aware of. The Elementals' autocast settings are shared between the Elemental pets. If you deactivate or activate it on one button, the matching button of the other Elementals will share that setting. We hope that this will be changed.  
 *Note: This only applies when talented into {{ site.data.talent.pe }}.*
 
 ### Q: "Do I use {{ site.data.spell.lvb }} during {{ site.data.talent.se }}?"
-{{ site.data.talent.se }} does not alter the rotation for the builds that use it during its duration, you will typically behave the same regardless of it being active.
+* {{ site.data.talent.se }} does not alter the rotation for the builds that use it during its duration, you will typically behave the same regardless of it being active.
 
 ### Q: "What is funnelling?"
-Funneling is the act of casting {{ site.data.spell.fs }} on multiple targets in order to generate {{ site.data.talent.lvs }} procs with the intention of increasing your damage on one target.
+* Funneling is the act of casting {{ site.data.spell.fs }} on multiple targets in order to generate {{ site.data.talent.lvs }} procs with the intention of increasing your damage on one target.
 
 ### Q: "Do you have any recommendation on how to sim and profiles to use while simming?"
-For a complete guide about Elemental's sim, see [this post]({{ site.baseurl }}{%link blog/_posts/2023-01-02-simming.md %}).
+* For a complete guide about Elemental's sim, see [this post]({{ site.baseurl }}{%link blog/_posts/2023-01-02-simming.md %}).
 
 ### Q: "What are some useful Macros?"
-See the [Macros]({{ site.baseurl }}{% link guide/general/macros.md %}) section of the guide.
+* See the [Macros]({{ site.baseurl }}{% link guide/general/macros.md %}) section of the guide.

--- a/guide/general/macros.md
+++ b/guide/general/macros.md
@@ -1,8 +1,8 @@
 ---
 layout: page
 title: Macros
-last_update: 30/12/2022 
-game_version: 10.0.2 Dragonflight
+last_update: 31/03/2023 
+game_version: 10.0.7 Dragonflight
 toc: true
 ---
 

--- a/guide/general/trinkets.md
+++ b/guide/general/trinkets.md
@@ -1,8 +1,8 @@
 ---
 layout: highcharts_page
 title: Trinkets
-last_update: 02/01/2023
-game_version: 10.0.2 Dragonflight
+last_update: 31/03/2023 
+game_version: 10.0.7 Dragonflight
 toc: true
 ---
 # Recommendations

--- a/guide/mythic_plus/DF_season_1.md
+++ b/guide/mythic_plus/DF_season_1.md
@@ -1,10 +1,11 @@
 ---
 layout: page
 title: "Mythic+ DF Season 1"
-last_update: 22/03/2023
+last_update: 29/03/2023
 game_version: 10.0.7 Dragonflight
 authors: Elivrio
-toc: false
+toc: true
+big_article: true
 ---
 
 # Introduction
@@ -13,40 +14,78 @@ This guide was made possible by:
 
 * Altenna (Discord: JudgeJames#0001 \| [Twitch](https://www.twitch.tv/judgejames) \| [Twitter](https://twitter.com/_judgejames_))
 * Amani (Discord: Amani#0001 \| [Discord Server](https://discordapp.com/invite/zTQhBn8) \| [YouTube](https://www.youtube.com/channel/UC5IikzgR1TeED-DxPLqISHg))
+* Elivrio (Discord: Elivrio#1450, in-game : Tyrindra-Ysondre)
 * Eokira (Discord: Eokira#7823)
 * Gaka (Discord: Gaka#7410)
 * HawkCorrigan (Discord: HawkCorrigan#1811)
-* Tyrindra [EU-Ysondre] (Discord: Elivrio#1450)
 
 Information on this page is written with the assumption that you understand the new priority list and talents in Dragonflight Season 1. If you have not done so, we highly recommend reading our other resources to learn about them!
 
 This guide is intended to help you identify critical mobs and abilities as well as improve your mechanical literacy in using your toolkit as an Elemental Shaman in each dungeon. If you have suggestions to improve the information in this guide please contact Eokira#7823 using the [Earthshrine Elemental channel](https://discord.gg/pGkPDzh7rP) or the [Storm, Earth & Lava discord](https://discord.gg/y5dUf3PWrU).
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png" width="130%"/></p>
 
 # Talents
 
 There are two main build that will be used in Dragonflight Season one : Wildfire and Lightning. You can find variation on each of them in the [build page](https://stormearthandlava.com/guide/general/builds.html).
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+This page will only note the important utility options that are available to you as an Elemental Shaman. Those remain suggestions and depending on your group, you might not need some of the talent suggested in this guide.
+
+### Standard Class tree for S1 Dungeons:
+
+<div class="iframe-holder">
+<iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAoEgUSChog0ikmSACRAC?width=530&level=70" frameborder="0" width="800px" height="100%"></iframe>
+</div>
+
+### A few remarks on this tree:
+- It has {{ site.data.talent.totemic_recall }} and points leading up to it. This is due to {{ site.data.talent.lmt }} being a staple in dungeon builds, making {{ site.data.talent.totemic_recall }} a required DPS node. If you are not playing {{ site.data.talent.lmt }}, you can remove the 4 points below {{ site.data.talent.gust_of_wind }} and allocate them elsewhere.
+- {{ site.data.talent.ee }} could be flexed around into another utility option but I believe it is the best single all rounder node to get to 20 points.
+- {{ site.data.talent.purge }} is recommended in all dungeon because of its high value this season.
+- Some people spec out of {{ site.data.spell.frs }}. It is still a very useful movement global, even without {{ site.data.talent.if }}.
+
+### The Last 4 Points
+Depending on the dungeon you are running and the group you're in, here is a list of good options to pick from:
+- {{ site.data.talent.earth_shield }} is a 2 points investments as you have to pick {{ site.data.talent.chain_heal }} to get it but it gives pretty good sustain.
+- {{ site.data.talent.thunderous_paws }} gives you a slow dispel and a burst of mobility that is often useful.
+- {{ site.data.talent.spirit_wolf }} is better mobility on a long distance, and can be used as a defensive.
+- {{ site.data.talent.healing_stream_totem }} and {{ site.data.talent.swirling_currents }} are good off-healing CDs. But the fact that you cannot predict who it will heal, paired with the GCD loss each time you use it make it very suboptimal and situational.
+- {{ site.data.talent.tremor_totem }} has a lot of minor uses this season but nothing... groundbreaking.
+- {{ site.data.talent.static_charge }} will allow you to have {{ site.data.talent.capacitor_totem }} on every packs. Very useful to complement another Class AoE CC.
+- {{ site.data.talent.guardians_cudgel }} on the other hand, will be best used when you are the only AoE CC of the group, or if you need successive interrupts on a pack ({{ site.data.dungeon.cos.blazing_imp }} in Court of Stars for example).
+- {{ site.data.talent.brimming_with_life }} is still a 8% max HP, even if it has the worst design in our whole tree.
+- {{ site.data.talent.cleanse_spirit }} is used only in Temple of the Jade Serpent this season, you can spend that point elsewhere when you're not in it. Note that the healers that cannot remove Curses are: Discipline Priest, Holy Priest, Holy Paladin, and Mistweaver Monk.
+- {{ site.data.talent.hex }} can be used to control Patrol's pathing and as a hard CC in general.
+- {{ site.data.talent.thunderstorm }} has some niche uses to gather pulls or deal with {{ site.data.affixes.sanguine }}. It can also be used as a Hard CC but {{ site.data.talent.thundershock }} will be better in that case. It’s also not that easy to utilize for less experienced players as it requires good positioning and awareness of timings to actually interrupt casts.
+- {{ site.data.talent.totemic_focus }} is a nice passive that will make it less likely for your tank to kite out of {{ site.data.talent.lmt }}'s range. The duration and width on {{ site.data.talent.wrt }} can also be nice.
+- {{ site.data.talent.spirit_walk }} is sometimes used as a slow dispel instead of {{ site.data.talent.gust_of_wind }}.
+- {{ site.data.talent.mana_spring_totem }} is less potent in dungeon than it is in raid. It's nice to have but doesn't really provide a lot either.
+- {{ site.data.talent.poison_cleansing_totem }} has a lot of minor uses this season but nothing... incurable.
+- {{ site.data.talent.stoneskin_totem }} is a very situational talent which gains a lot of value in higher keys, saving your tank and your party from big physical attacks and bleeds.
+
+### 24 keys and higher:
+When pushing in higher keys, some talents become mandatory to survive:
+- {{ site.data.talent.spirit_wolf }} is used as a defensive talent, requiring you to sit and tank the damage in wolf form until it's safe to switch back.
+- {{ site.data.talent.brimming_with_life }} is required for the 8% max HP. In certain dungeons at this key level, if you lose {{ site.data.spell.ankh }}, it can instantly be a deplete because you will die on other abilities later on.  
+
+*Note: Again, these become mandatory only in higher keys and can be skipped when you are not in the hardest version of m+.*
+
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png" width="130%"/></p>
 
 # Miscellaneous Tips
 
-* Although strategies are listed for mobs and bosses, communicating with your group how each pull should be executed is more important. Some suggestions may not be applicable depending on your group's strategy.
+* Although strategies are listed for mobs and bosses, communicating with your group how each pull should be executed is more important. Some suggestions may not be applicable depending on your group's strategy. For example, plan with your group in advance on where to use {{ site.data.spell.bl }}.
+
+* **Stop cast**, or **Hard CC**, refers to cancelling enemy casts using hard Crowd Control abilities. While some casts cannot be interrupted, they can be cancelled by other means. Regularly be mindful of lethal trash abilities. Also know what you can do to stop a cast and look for alternative ways to interrupt casts if no interrupts are available. Elemental Shaman may stop casts with {{ site.data.talent.capacitor_totem }}, {{ site.data.talent.hex }}, {{ site.data.talent.thunderstorm }} (or {{ site.data.talent.thundershock }}), {{ site.data.talent.lightning_lasso }} and {{ site.data.spell.eq }}'s knockdowns.
+
+* Routinely support your healer and your group with healing abilities such as {{ site.data.talent.ag }}, {{ site.data.talent.healing_stream_totem }} or even {{ site.data.talent.cleanse_spirit }}.
+
+* Often times, your tank may need to kite. Remember the kiting tools at your disposal ({{ site.data.spell.earthbind_totem }}, {{ site.data.spell.frs }}, {{ site.data.talent.capacitor_totem }}, etc.) to distance trash packs away from your tank.
+
+* Use your CDs. {{ site.data.talent.fe }}, {{ site.data.talent.se }}, {{ site.data.talent.sk }}, {{ site.data.talent.lmt }} or even {{ site.data.talent.ee }}, {{ site.data.talent.swg }} and {{ site.data.talent.ag }} are useless if you never press them cause you are waiting for "the right moment". Planning CDs is even better but learn to press them first and foremost.
+
+* Try to setup pulls in advance. In Wildfire builds, try to keep maelstrom at the end of a pack to get {{ site.data.spell.eq }}, {{ site.data.talent.sop }} and {{ site.data.spell.fs }} spreading at the start of the next pull. In Lightning builds, try to get an {{ site.data.talent.eogs }} buff ready when the pull is being setup by the tank. Try to cast {{ site.data.talent.sk }} before pulls to keep uptime during it, etc.
 
 * {{ site.data.talent.ee }} is a potent ability best used to soak damage away from the tank or as an emergency button to avoid a party wipe. Communicate with your tank on using {{ site.data.talent.ee }} for challenging trash packs as well as remind your healer to keep the {{ site.data.talent.ee }} healthy as needed. Remember that with {{ site.data.talent.primal_elementalist }}, you can manually move the pet and single-target stun with {{ site.data.spell.pulverize }}. However, keep in mind that you cannot have {{ site.data.talent.ee }} and {{ site.data.talent.fe }} summoned at the same time with {{ site.data.talent.primal_elementalist }}.
-
-* Often times, your tank may need to kite. Remember the kiting tools at your disposal ({{ site.data.spell.earthbind_totem }}, {{ site.data.spell.frs }}, {{ site.data.talent.capacitor_totem }}, {{ site.data.talent.thunderstorm }}, {{ site.data.talent.thundershock }}, {{ site.data.talent.earthgrab_totem }}) to distance trash packs away from your tank.
-
-* Routinely support your healer and your group with healing abilities and {{ site.data.talent.cleanse_spirit }}. Note that the healers that cannot remove Curses are: Discipline Priest, Holy Priest, Holy Paladin, and Mistweaver Monk.
-
-* Plan with your group in advance on where to use {{ site.data.spell.bl }}.
-
-* Some dungeons do not require {{ site.data.talent.purge }} or {{ site.data.talent.cleanse_spirit }}. You can spend that talent point somewhere else in the tree.
-
-* Try to keep maelstrom at the end of a pack to get {{ site.data.spell.eq }}, {{ site.data.talent.sop }} and {{ site.data.spell.fs }} spreading at the start of the next pull.
-
-* Use your CDs. {{ site.data.talent.fe }}, {{ site.data.talent.se }}, {{ site.data.talent.sk }}, {{ site.data.talent.lmt }} or even {{ site.data.talent.ee }}, {{ site.data.talent.swg }} and {{ site.data.talent.ag }} are useless if you never press them cause you are waiting for "the right moment". Planning CDs is even better but learn to press them first.
 
 * Die and retry. You need to experience a lot of death and bad keys to know when a key is good.
 
@@ -56,7 +95,7 @@ There are two main build that will be used in Dragonflight Season one : Wildfire
 
 * [Learn to log your dungeon runs!](https://www.warcraftlogs.com/help/start) Warcraft Logs filters dungeons with pull-by-pull analyses and records replays of dungeon runs. Having logs available to share is helpful for you to receive actionable feedback.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png" width="130%"/></p>
 
 # Affixes
 
@@ -102,12 +141,12 @@ The affixes {{ site.data.affixes.necrotic }} and {{ site.data.affixes.inspiring 
 * During high stress situation, it might be best to clear the marks as soon as possible to avoid bad overlaps.
 * When running back after dying, consider waiting a bit before entering the 100 yards range of your party if they are still in battle. If you have the debuff on you, you would most likely kill your party and yourself.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png" width="130%"/></p>
 
 # Dungeons
-<p style="color:red">Click on a dungeon banner to expand it.</p>
 
-<hr>
+<p style="color:red" align="center">Click on a dungeon banner to expand it.</p>
+
 <div class="dungeon-accordion">
 
 <div id="accordion">
@@ -118,31 +157,25 @@ The affixes {{ site.data.affixes.necrotic }} and {{ site.data.affixes.inspiring 
 <div id="aa-collapse" class="collapse" aria-labelledby="aa" data-parent="#accordion">
 <div class="card-body" markdown="1">
 
-## Talent
+### Notable Talent Choices
 
-### Notable talent choices
-
-* {{ site.data.talent.tremor_totem }} can be used to reduce the amount of kicks needed in {{ site.data.dungeon.aa.vexamus }} area.
-* {{ site.data.talent.poison_cleansing_totem }} can be used to help tank and healer in {{ site.data.dungeon.aa.overgrown_ancient }} area.
+* {{ site.data.talent.tremor_totem }} can be used to reduce the amount of kicks needed in {{ site.data.dungeon.aa.vexamus }}' area.
+* {{ site.data.talent.poison_cleansing_totem }} can be used to help the tank and the healer in {{ site.data.dungeon.aa.overgrown_ancient }}'s area.
 * {{ site.data.talent.purge }} has some uses in the area before the last boss.
+* {{ site.data.talent.stoneskin_totem }} can be used in higher key for {{ site.data.dungeon.aa.crawth }}'s {{ site.data.dungeon.aa.savage_peck }} and {{ site.data.dungeon.aa.overgrown_ancient }}'s {{ site.data.dungeon.aa.splinterbark }} and {{ site.data.dungeon.aa.barkbreaker }}.
 
-### Wildfire
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-<div class="iframe-holder">
-<iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAg0SrJJtkAJINKRLtkQOAAAAAAgSASJJRIKItIppEJIEBI?width=530&level=70" frameborder="0" width="530px" height="100%"></iframe>
-</div>
-
-![Line Break](/assets/img/blog/bluelinebreak.png)
-
-## Dungeon buffs
+### Dungeon buffs
 
 * {{ site.data.dungeon.aa.bronze_dragonflight_pledge_pin }} will be the default choice for most runs.
 * {{ site.data.dungeon.aa.black_dragonflight_pledge_pin }} is the alternative if you want more AoE damage.
+* {{ site.data.dungeon.aa.red_dragonfligh_pledge_pin }} is also an option in higher keys for survivability gain.
 * Do not pick {{ site.data.dungeon.aa.blue_dragonflight_pledge_pin }}. It gives rating and as such, it will be impacted by diminishing return.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-## {{ site.data.dungeon.aa.vexamus }} trash
+### {{ site.data.dungeon.aa.vexamus }} trash
 
 **{{ site.data.dungeon.aa.spellbound_scepter }}**
 * Use {{ site.data.spell.wind_shear }} to interrupt {{ site.data.dungeon.aa.mystic_blast }} in priority.
@@ -157,17 +190,17 @@ The affixes {{ site.data.affixes.necrotic }} and {{ site.data.affixes.inspiring 
 **{{ site.data.dungeon.aa.arcane_ravager }}**
 * {{ site.data.dungeon.aa.arcane_ravager }} will jump on a random player with {{ site.data.dungeon.aa.vicious_ambush }} and cast a {{ site.data.dungeon.aa.riftbreath }} frontal. Beware of it at all times and use {{ site.data.talent.swg }} to reposition as needed.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-## {{ site.data.dungeon.aa.vexamus }}
+### {{ site.data.dungeon.aa.vexamus }}
 
 * Soak the {{ site.data.dungeon.aa.arcane_orbs }} but try to let the {{ site.data.dungeon.aa.oversurge }} debuff fall off before soaking another. Use {{ site.data.talent.as }} at higher stacks.
 * Spread with {{ site.data.dungeon.aa.mana_bombs }} and try to drop pools along the walls.
 * Beware of {{ site.data.dungeon.aa.arcane_fissure }}, it does a lot of direct damage. Use {{ site.data.talent.as }} as needed. {{ site.data.talent.swg }} will allow you to keep uptime while dodging the swirlies.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-## {{ site.data.dungeon.aa.crawth }} trash
+### {{ site.data.dungeon.aa.crawth }} trash
 
 **{{ site.data.dungeon.aa.guardian_sentry }}**
 * Get out or line of sight the big {{ site.data.dungeon.aa.expel_intruders }} cast.
@@ -178,9 +211,9 @@ The affixes {{ site.data.affixes.necrotic }} and {{ site.data.affixes.inspiring 
 * Use {{ site.data.spell.wind_shear }} to interrupt {{ site.data.dungeon.aa.call_of_the_flock }}.
 * Dodge the {{ site.data.dungeon.aa.gust }} frontal.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-## {{ site.data.dungeon.aa.crawth }}
+### {{ site.data.dungeon.aa.crawth }}
 
 * Try to keep your offensive CDs and {{ site.data.spell.bl }} for when you trigger {{ site.data.dungeon.aa.firestorm }}. The boss will take 75% more damage for 12 seconds.
 * Dodge the {{ site.data.dungeon.aa.firestorm }} swirlies and the {{ site.data.dungeon.aa.overpowering_gust }} frontal.
@@ -188,9 +221,9 @@ The affixes {{ site.data.affixes.necrotic }} and {{ site.data.affixes.inspiring 
 * Pick up wind orbs for 45% haste and a "cast while moving" buff for 20s. Do not overlap the orb buff with {{ site.data.talent.swg }}.
 * Try to be at full health before {{ site.data.dungeon.aa.deafening_screech }} or use {{ site.data.talent.as }}, especially at high {{ site.data.dungeon.aa.sonic_vulnerability }} stacks.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-## {{ site.data.dungeon.aa.overgrown_ancient }} trash
+### {{ site.data.dungeon.aa.overgrown_ancient }} trash
 
 **{{ site.data.dungeon.aa.hungry_lasher }}**
 * Use {{ site.data.talent.poison_cleansing_totem }} if talented to help the tank with the {{ site.data.dungeon.aa.lasher_toxin }} stacks.
@@ -202,9 +235,9 @@ The affixes {{ site.data.affixes.necrotic }} and {{ site.data.affixes.inspiring 
 * These mobs will charge on you with {{ site.data.dungeon.aa.darting_sting }}, do not be at max range to keep them near melees for uptime.
 * Consider using {{ site.data.talent.as }} at low health.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-## {{ site.data.dungeon.aa.overgrown_ancient }}
+### {{ site.data.dungeon.aa.overgrown_ancient }}
 
 * The boss will use {{ site.data.dungeon.aa.burst_forth }} after two {{ site.data.dungeon.aa.germinate }} casts. Keep AoE CDs such as {{ site.data.talent.sk }} or {{ site.data.talent.lmt }} to quickly burst down the adds after the second {{ site.data.dungeon.aa.germinate }} cast.
 * Move with your group during {{ site.data.dungeon.aa.germinate }} to keep adds stacked for cleave. Use {{ site.data.talent.swg }} to start ramping when a {{ site.data.dungeon.aa.burst_forth }} is coming soon.
@@ -213,9 +246,9 @@ The affixes {{ site.data.affixes.necrotic }} and {{ site.data.affixes.inspiring 
 * Hard switch on the {{ site.data.dungeon.aa.ancient_branch }} whenever it spawns.
 * Use {{ site.data.spell.wind_shear }} to interrupt {{ site.data.dungeon.aa.healing_touch }} from {{ site.data.dungeon.aa.ancient_branch }}.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-## {{ site.data.dungeon.aa.echo_of_doragosa }} trash
+### {{ site.data.dungeon.aa.echo_of_doragosa }} trash
 
 **{{ site.data.dungeon.aa.algethar_echoknight }}**
 * Don't be in melee range when {{ site.data.dungeon.aa.algethar_echoknight }} uses {{ site.data.dungeon.aa.astral_whirlwind }}.
@@ -227,9 +260,9 @@ The affixes {{ site.data.affixes.necrotic }} and {{ site.data.affixes.inspiring 
 **{{ site.data.dungeon.aa.ethereal_restorer }}**
 * Use {{ site.data.talent.purge }} to dispel {{ site.data.dungeon.aa.celestial_shield }} as soon as possible.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-## {{ site.data.dungeon.aa.echo_of_doragosa }}
+### {{ site.data.dungeon.aa.echo_of_doragosa }}
 
 * Stay close to the boss but be spreaded to avoid {{ site.data.dungeon.aa.astral_breath }} and drop {{ site.data.dungeon.aa.energy_bomb }}.
 * When at two stacks of {{ site.data.dungeon.aa.overwhelming_power }}, stand close to wall to create the {{ site.data.dungeon.aa.arcane_rift }} in a nice spot.
@@ -247,29 +280,18 @@ The affixes {{ site.data.affixes.necrotic }} and {{ site.data.affixes.inspiring 
 <div id="cos-collapse" class="collapse" aria-labelledby="cos" data-parent="#accordion">
 <div class="card-body" markdown="1">
 
-## Talent
+### Notable Talent Choices
 
-### Notable talent choices
-
-* Court of Stars is a dungeon with many small packs and many mini-bosses. A build that does more Single Target damage while cleaving will perform better on average than a full AoE build.
+* Court of Stars is a dungeon with many small packs and many mini-bosses. Depending your group composition, Single Target Oriented build that does good on demand AoE will perform better on average than a full AoE build. I recommend using the "Primordial Surge with Stormkeeper" from the [Build Page](https://stormearthandlava.com/guide/general/builds.html#primordial-surge-builds).
 * {{ site.data.talent.hex }} is a good option in this dungeon to control patrols, adds on first boss and hard CC breaks in general.
 * {{ site.data.talent.spirit_walk }} and {{ site.data.talent.thunderous_paws }} can be used to cleanse the debuff on the first boss.
 * {{ site.data.talent.purge }} has some uses in the area before the first boss.
+* {{ site.data.talent.guardians_cudgel }} and {{ site.data.talent.thunderstorm }} are very good hard CC to deal with the {{ site.data.dungeon.cos.blazing_imp }} packs.
+* {{ site.data.talent.stoneskin_totem }} can be used in higher key for {{ site.data.dungeon.cos.imacutya }}'s damage on the tank and {{ site.data.dungeon.cos.advisor_melandrus }}'s {{ site.data.dungeon.cos.slicing_maelstrom }}.
 
-### SK MwF PSurge
-<div class="iframe-holder">
-<iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAgUSrJJtkAJINKBtkkkDAAAAAAoEgUSCpJKi0ikiSIIEBI?width=530&level=70" frameborder="0" width="530px" height="100%"></iframe>
-</div>
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-### Wildfire
-A full AoE build is still a good option depending on your route and your party composition.
-<div class="iframe-holder">
-<iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAg0SrJJtkAJINKRLtkQOAAAAAAgSASJJkmoISLSKKhgQEgA?width=530&level=70" frameborder="0" width="530px" height="100%"></iframe>
-</div>
-
-![Line Break](/assets/img/blog/bluelinebreak.png)
-
-## {{ site.data.dungeon.cos.patrol_captain_gerdo }} trash
+### {{ site.data.dungeon.cos.patrol_captain_gerdo }} trash
 
 **{{ site.data.dungeon.cos.duskwatch_guard }}**
 * Dodge the {{ site.data.dungeon.cos.quelling_strike }} frontal.
@@ -295,9 +317,9 @@ A full AoE build is still a good option depending on your route and your party c
 **{{ site.data.dungeon.cos.arcane_manifestation }}**
 * Use {{ site.data.spell.wind_shear }} to interrupt {{ site.data.dungeon.cos.drain_magic }}.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-## {{ site.data.dungeon.cos.patrol_captain_gerdo }}
+### {{ site.data.dungeon.cos.patrol_captain_gerdo }}
 
 * Don't forget to add poison to the {{ site.data.dungeon.cos.flask_of_the_solemn_night }} if you're an Alchemist, it will kill the boss at 25%.
 * Gerdo will cast {{ site.data.dungeon.cos.signal_beacon }} at 75% HP, spawning {{ site.data.dungeon.cos.duskwatch_reinforcement }} from the remaining active Arcane Beacons.
@@ -306,17 +328,17 @@ A full AoE build is still a good option depending on your route and your party c
 * {{ site.data.dungeon.cos.streetsweeper }} will spawn orbs that do damage in a line after 3 seconds. Beware of {{ site.data.dungeon.cos.arcane_lockdown }} potentially slowing you.
 * Stay farther than 20 yards away to ignore {{ site.data.dungeon.cos.resonant_slash }}.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-## Dungeon Buffs
+### Dungeon Buffs
 
 The area before the second boss is full of items that players can interact with based upon race, profession choice, class, or even role.
 Shamans can interact with the {{ site.data.dungeon.cos.waterlogged_scroll }} that is accessible near the fountain to give 35% movement speed to their party.
 You can find a complete list of all of the accessible items and buff on [this link](https://www.wowhead.com/guide/mythic-plus-dungeons/court-of-stars-strategy#overview-dungeon-buffs).
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-## {{ site.data.dungeon.cos.talixae_flamewreath }} trash
+### {{ site.data.dungeon.cos.talixae_flamewreath }} trash
 
 **{{ site.data.dungeon.cos.watchful_inquisitor }}**
 * Use {{ site.data.spell.wind_shear }} to interrupt {{ site.data.dungeon.cos.searing_glare }}.
@@ -348,15 +370,15 @@ You can find a complete list of all of the accessible items and buff on [this li
 **{{ site.data.dungeon.cos.jazshariu }}**
 * Dodge the {{ site.data.dungeon.cos.crushing_leap_cos }} swirlies and the following {{ site.data.dungeon.cos.shockwave }} frontal.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-## {{ site.data.dungeon.cos.talixae_flamewreath }}
+### {{ site.data.dungeon.cos.talixae_flamewreath }}
 
 * Stay packed at all time on your tank. Use {{ site.data.talent.swg }} to keep uptime while moving.
 * You can solo kick {{ site.data.dungeon.cos.withering_soul }}! Notify your group to avoid over-kicking. Your party will have more kicks for the {{ site.data.dungeon.cos.blazing_imp }} if needed.
 * Dodge the {{ site.data.dungeon.cos.infernal_eruption }} swirlies then blast the group of {{ site.data.dungeon.cos.blazing_imp }}. Use {{ site.data.talent.capacitor_totem }} if they are about to cast.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
 ### Hide and Seek minigame
 
@@ -367,9 +389,9 @@ Good luck for the mini-game ! Remember to pick up all of the clues, especially i
 * Use {{ site.data.spell.wind_shear }} to interrupt {{ site.data.dungeon.cos.shadow_bolt_volley }}.
 * Use {{ site.data.talent.capacitor_totem }} or {{ site.data.talent.hex }} to interrupt the {{ site.data.dungeon.cos.hypnosis_bat }} cast.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-## {{ site.data.dungeon.cos.advisor_melandrus }}
+### {{ site.data.dungeon.cos.advisor_melandrus }}
 
 * Dodge {{ site.data.dungeon.cos.blade_surge }} swirlies. It will be casted on a player outside of melee if possible. This spell leaves a clone that will replicate {{ site.data.dungeon.cos.slicing_maelstrom }} and {{ site.data.dungeon.cos.piercing_gale }}.
 * Dodge the line on the ground from {{ site.data.dungeon.cos.piercing_gale }}. They come from both {{ site.data.dungeon.cos.advisor_melandrus }} and his clones.
@@ -390,25 +412,19 @@ Good luck for the mini-game ! Remember to pick up all of the clues, especially i
 <div id="hov-collapse" class="collapse" aria-labelledby="hov" data-parent="#accordion">
 <div class="card-body" markdown="1">
 
-## Miscellaneous Tips
+### Miscellaneous Tips
 
 * There are many frontals and cleaves in this dungeon. Staying away from the tank is generally a good idea.
 
-## Talents
-
 ### Notable Talent Choices
-* {{ site.data.talent.purge }} has some uses, notably on the {{ site.data.dungeon.hov.stormforged_sentinel }}.
+* {{ site.data.talent.purge }} has some really good uses, notably on the {{ site.data.dungeon.hov.stormforged_sentinel }}.
 * Halls of Valor is a really intensive healing dungeon, {{ site.data.talent.ag }} has a lot of value, notably on bosses.
+* The bosses are pretty dangerous, notably in {{ site.data.affixes.tyrannical }}. Consider running {{ site.data.talent.spirit_wolf }} and {{ site.data.talent.brimming_with_life }} for extra survivability.
+* {{ site.data.talent.stoneskin_totem }} can be used in higher key for {{ site.data.dungeon.hov.hymdall }}'s {{ site.data.dungeon.hov.horn_of_valor }} and {{ site.data.dungeon.hov.fenryr }}'s {{ site.data.dungeon.hov.claw_frenzy }}.
 
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-### Wildfire
-<div class="iframe-holder">
-<iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAg0SrJJtkAJINKRLtkQOAAAAAAgSASJJkmog0SSaKhgQEgA?width=530&level=70" frameborder="0" width="530px" height="100%"></iframe>
-</div>
-
-![Line Break](/assets/img/blog/bluelinebreak.png)
-
-## {{ site.data.dungeon.hov.hymdall }} trash
+### {{ site.data.dungeon.hov.hymdall }} trash
 
 **{{ site.data.dungeon.hov.valarjar_champion }}**
 * Don't be on the tank, {{ site.data.dungeon.hov.power_attack }} cleaves.
@@ -420,18 +436,18 @@ Good luck for the mini-game ! Remember to pick up all of the clues, especially i
 * Watch out for the {{ site.data.dungeon.hov.lightning_breath }} frontal.
 * Dodge the {{ site.data.dungeon.hov.crackling_storm }} swirly and the following tornado. Use {{ site.data.talent.swg }} to keep uptime while dodging.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-## {{ site.data.dungeon.hov.hymdall }}
+### {{ site.data.dungeon.hov.hymdall }}
 
 * Stand close to the walls to bait {{ site.data.dungeon.hov.dancing_blade }} out of the way.
 * Never be on the tank, {{ site.data.dungeon.hov.bloodletting_sweep }} cleaves.
 * {{ site.data.dungeon.hov.horn_of_valor }} will call 3 drakes that will fill with lightning the 3 sections of the room one after the other. Always pay attention to these drakes and move to the correct spot to dodge the {{ site.data.dungeon.hov.static_field }} and the following {{ site.data.dungeon.hov.ball_lightning }}. Use {{ site.data.talent.swg }} to keep uptime while dodging.
 * {{ site.data.dungeon.hov.horn_of_valor }} also does a lot of initial damage. Use {{ site.data.talent.as }} before it if you are not confident in your current HP.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-## {{ site.data.dungeon.hov.hyrja }} trash
+### {{ site.data.dungeon.hov.hyrja }} trash
 
 **{{ site.data.dungeon.hov.valarjar_runecarver }}**
 * Use {{ site.data.spell.wind_shear }} to interrupt {{ site.data.dungeon.hov.etch }} in priority and {{ site.data.dungeon.hov.shattered_rune }} if possible.
@@ -464,9 +480,9 @@ Good luck for the mini-game ! Remember to pick up all of the clues, especially i
 * Dodge the orbs of light during {{ site.data.dungeon.hov.sanctify }}. Use {{ site.data.talent.swg }} to keep uptime while dodging.
 * Use {{ site.data.spell.wind_shear }} to interrupt {{ site.data.dungeon.hov.searing_light }}.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-## {{ site.data.dungeon.hov.hyrja }}
+### {{ site.data.dungeon.hov.hyrja }}
 
 * This is a very intense fight healing wise. Be ready to pop {{ site.data.talent.as }}, {{ site.data.talent.ee }} or even {{ site.data.item.potion_rhp }} and {{ site.data.item.hs }}.
 * Hide under the dome during {{ site.data.dungeon.hov.eye_of_the_storm }}. This is a great place to use {{ site.data.talent.ag }} and {{ site.data.talent.as }}.
@@ -474,9 +490,9 @@ Good luck for the mini-game ! Remember to pick up all of the clues, especially i
 * Dodge the orbs of light during {{ site.data.dungeon.hov.sanctify }}. Use {{ site.data.talent.swg }} to keep uptime while dodging.
 * Don't be near your tank after {{ site.data.dungeon.hov.eye_of_the_storm }} and {{ site.data.dungeon.hov.sanctify }}, she will use {{ site.data.dungeon.hov.shield_of_light }}, a frontal beam on him.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-## {{ site.data.dungeon.hov.fenryr }} trash
+### {{ site.data.dungeon.hov.fenryr }} trash
 
 **{{ site.data.dungeon.hov.angerhoof_bull }}**
 * Stay farther than 12 yards away to ignore {{ site.data.dungeon.hov.rumbling_stomp }}.
@@ -487,18 +503,18 @@ Good luck for the mini-game ! Remember to pick up all of the clues, especially i
 **{{ site.data.dungeon.hov.ebonclaw_worg }}**
 * These mobs are super deadly. They buff themselves while pulled together then jump on ranged players with {{ site.data.dungeon.hov.leap_for_the_throat }}. Stay close to melee but spreaded and use {{ site.data.talent.as }} as required.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-## {{ site.data.dungeon.hov.fenryr }}
+### {{ site.data.dungeon.hov.fenryr }}
 
 * Stay near the boss to help soak {{ site.data.dungeon.hov.claw_frenzy }}.
 * Stop casting to not get silenced by {{ site.data.dungeon.hov.unnerving_howl }}.
 * Kite the boss if you are targeted by {{ site.data.dungeon.hov.scent_of_blood }}. Be careful not to run into the remaining {{ site.data.dungeon.hov.ebonclaw_worg }} in the area. Use {{ site.data.talent.swg }} to keep uptime while kiting.
 * Spread when targeted with {{ site.data.dungeon.hov.ravenous_leap }}. Quickly come back to help soak {{ site.data.dungeon.hov.claw_frenzy }}.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-## {{ site.data.dungeon.hov.god_king_skovald }} trash
+### {{ site.data.dungeon.hov.god_king_skovald }} trash
 
 The 4 kings in the area must be defeated for {{ site.data.dungeon.hov.god_king_skovald }} to spawn. They each have a unique ability and defeating one grants his ability to the other ones. You must engage one, then another, then the last two will attack together. It's possible to speed up this proccess by picking up a {{ site.data.dungeon.hov.mug_of_mead }} in the banquet's hall. Throw the {{ site.data.dungeon.hov.mug_of_mead }} on a king, then talk to another one then kite it over the king spreaded with mead. They will start to fight allowing you to engage the second king. [This video](https://youtu.be/CdZvi8jKUMc) explains the method and [this one](https://youtu.be/eQx4c8FyrcA) explains an advanced version with all 4 kings.
 
@@ -514,14 +530,14 @@ The 4 kings in the area must be defeated for {{ site.data.dungeon.hov.god_king_s
 **{{ site.data.dungeon.hov.king_tor }}**
 * Use your CCs to help kiting the Ancestors spawned by {{ site.data.dungeon.hov.call_ancestor }}. {{ site.data.spell.earthbind_totem }}, {{ site.data.talent.capacitor_totem }}, {{ site.data.talent.earthgrab_totem }}, {{ site.data.talent.thunderstorm }}, {{ site.data.talent.thundershock }} and {{ site.data.talent.lightning_lasso }} all work !
 
-## {{ site.data.dungeon.hov.god_king_skovald }}
+### {{ site.data.dungeon.hov.god_king_skovald }}
 
 * Stay spreaded, he will target a random player with {{ site.data.dungeon.hov.felblaze_rush }}, hitting everyone within 6 yards. Use {{ site.data.talent.as }} as needed.
 * Stand behind {{ site.data.dungeon.hov.aegis_of_aggramar }} during {{ site.data.dungeon.hov.ragnarok }}.
 * When Skovald uses the {{ site.data.dungeon.hov.aegis_of_aggramar }}, get around the shield to hit him.
 * Kite the {{ site.data.dungeon.hov.flame_of_woe }}, if possible with {{ site.data.talent.swg }}. You can spread {{ site.data.spell.fs }} on the {{ site.data.dungeon.hov.flame_of_woe }} for {{ site.data.talent.splinter }} value. Be quick about it because they will burn themselves out with {{ site.data.dungeon.hov.consuming_flame }}.
 
-## {{ site.data.dungeon.hov.odyn }}
+### {{ site.data.dungeon.hov.odyn }}
 
 * Focus target {{ site.data.dungeon.hov.stormforged_obliterator }} as soon as it spawns. Interrupt and CC it while kiting away from {{ site.data.dungeon.hov.radiant_tempest }}. Be careful not to be too far from {{ site.data.dungeon.hov.stormforged_obliterator }} or you will not be able to interrupt his {{ site.data.dungeon.hov.surge_hov }}.
 * Avoid {{ site.data.dungeon.hov.spear_of_light }} swirlies and {{ site.data.dungeon.hov.glowing_fragment }} orbs.
@@ -540,21 +556,15 @@ The 4 kings in the area must be defeated for {{ site.data.dungeon.hov.god_king_s
 <div id="rlp-collapse" class="collapse" aria-labelledby="rlp" data-parent="#accordion">
 <div class="card-body" markdown="1">
 
-## Talents
-
 ### Notable Talent Choices
 * {{ site.data.talent.purge }} is very potent in Ruby Life Pools, allowing you to execute adds and dispel shields.
 * Ruby Life Pools is a really intensive healing dungeon, {{ site.data.talent.ag }} has a lot of value, notably on bosses and minibosses.
+* The bosses are pretty dangerous, notably in {{ site.data.affixes.tyrannical }}. Consider running {{ site.data.talent.spirit_wolf }} and {{ site.data.talent.brimming_with_life }} for extra survivability.
+* {{ site.data.talent.stoneskin_totem }} can be used in higher key to reduce tank damage on the second and third boss.
 
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-### Wildfire
-<div class="iframe-holder">
-<iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAg0SrJJtkAJINKRLtkQOAAAAAAgSASJJkmog0SSaKhgQEgA?width=530&level=70" frameborder="0" width="530px" height="100%"></iframe>
-</div>
-
-![Line Break](/assets/img/blog/bluelinebreak.png)
-
-## {{ site.data.dungeon.rlp.melidrussa_chillworn }} trash
+### {{ site.data.dungeon.rlp.melidrussa_chillworn }} trash
 
 **{{ site.data.dungeon.rlp.flashfrost_chillweaver }}**
 * Use {{ site.data.spell.wind_shear }} to interrupt {{ site.data.dungeon.rlp.ice_shield }}.
@@ -571,9 +581,9 @@ The 4 kings in the area must be defeated for {{ site.data.dungeon.hov.god_king_s
 * Dodge his {{ site.data.dungeon.rlp.blazing_rush }} charge on a random player. Don't make him charge into the eggs in the area or {{ site.data.dungeon.rlp.infused_whelp }} will spawn.
 * Dodge the red swirlies created by {{ site.data.dungeon.rlp.steel_barrage }}. Use {{ site.data.talent.swg }} to keep uptime while dodging.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-## {{ site.data.dungeon.rlp.melidrussa_chillworn }}
+### {{ site.data.dungeon.rlp.melidrussa_chillworn }}
 
 * Stay packed with your group to drop {{ site.data.dungeon.rlp.hailbombs }} in the same general area.
 * Move away from the group to drop {{ site.data.dungeon.rlp.chillstorm }}. Use {{ site.data.talent.gust_of_wind }}
@@ -581,9 +591,9 @@ to quickly leave the AoE.  Use {{ site.data.talent.swg }} to keep uptime while g
 * Use {{ site.data.talent.as }} and {{ site.data.talent.ag }} during {{ site.data.dungeon.rlp.frost_overload }} to survive. Use CDs to quickly burst her shield.
 * The {{ site.data.dungeon.rlp.infused_whelp }} that spawn are not a priority DPS, but it's important that they die so the tank doesn't get stunned by {{ site.data.dungeon.rlp.cold_claws }}. You can arrange with your group for a single person to do AoE and the other DPS to funnel damage into {{ site.data.dungeon.rlp.melidrussa_chillworn }}.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-## {{ site.data.dungeon.rlp.kokia_blazehoof }} trash
+### {{ site.data.dungeon.rlp.kokia_blazehoof }} trash
 
 **{{ site.data.dungeon.rlp.primalist_cinderweaver }}**
 * Use {{ site.data.spell.wind_shear }} to interrupt {{ site.data.dungeon.rlp.cinderbolt }}.
@@ -606,9 +616,9 @@ to quickly leave the AoE.  Use {{ site.data.talent.swg }} to keep uptime while g
 * {{ site.data.dungeon.rlp.molten_blood }} does ramping damage starting at 50% HP. Use {{ site.data.talent.ag }} to help the healer below that threshold.
 * Use {{ site.data.talent.as }} as required.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-## {{ site.data.dungeon.rlp.kokia_blazehoof }}
+### {{ site.data.dungeon.rlp.kokia_blazehoof }}
 
 * Bait the first {{ site.data.dungeon.rlp.ritual_of_blazebinding }} at 15 yards from the boss, then bait the others with your group.
 * Bait {{ site.data.dungeon.rlp.molten_boulder }} into the walls or into previous magma pools. Beware of an early explosion of the boulder if you are close to a wall.
@@ -620,9 +630,9 @@ to quickly leave the AoE.  Use {{ site.data.talent.swg }} to keep uptime while g
 
 *Note:* Learning the timings to correctly bait the {{ site.data.dungeon.rlp.molten_boulder }} and {{ site.data.dungeon.rlp.ritual_of_blazebinding }} will make this fight significantly easier.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-## {{ site.data.dungeon.rlp.kyrakka }} and {{ site.data.dungeon.rlp.erkhart_stormvein }} trash
+### {{ site.data.dungeon.rlp.kyrakka }} and {{ site.data.dungeon.rlp.erkhart_stormvein }} trash
 
 **{{ site.data.dungeon.rlp.storm_warrior }}**
 * One of the only mobs that does nothing but tank damage this season. Worth noting.
@@ -645,9 +655,9 @@ to quickly leave the AoE.  Use {{ site.data.talent.swg }} to keep uptime while g
 * You want to use {{ site.data.talent.purge }} on {{ site.data.dungeon.rlp.primal_thundercloud }} **in priority** to remove as many {{ site.data.dungeon.rlp.tempest_barrier }} as possible.
 * Use {{ site.data.talent.ag }} and {{ site.data.talent.as }} to mitigate {{ site.data.dungeon.rlp.lightning_storm }}.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-## {{ site.data.dungeon.rlp.kyrakka }} and {{ site.data.dungeon.rlp.erkhart_stormvein }}
+### {{ site.data.dungeon.rlp.kyrakka }} and {{ site.data.dungeon.rlp.erkhart_stormvein }}
 
 * {{ site.data.dungeon.rlp.kyrakka }} will **always** be the priority target in phase 1 and 2. As a ranged player, target her whenever she is in range.
 * During phase 1, you want to stay between the two pillars of the room as much as possible to bait {{ site.data.dungeon.rlp.kyrakka }} into landing for better uptime.
@@ -669,20 +679,13 @@ to quickly leave the AoE.  Use {{ site.data.talent.swg }} to keep uptime while g
 <div id="sbg-collapse" class="collapse" aria-labelledby="sbg" data-parent="#accordion">
 <div class="card-body" markdown="1">
 
-## Talents
-
 ### Notable Talent Choices
-* {{ site.data.talent.purge }} has some good uses, allowing you dispel big shields notably.
+* {{ site.data.talent.purge }} has some good uses, allowing you dispel big shields after the first boss notably.
 * {{ site.data.talent.tremor_totem }} can be used on the adds after the first boss.
 
-### Wildfire
-<div class="iframe-holder">
-<iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAg0SrJJtkAJINKRLtkQOAAAAAAgSASJJkmog0SSaKhgQEgA?width=530&level=70" frameborder="0" width="530px" height="100%"></iframe>
-</div>
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
-
-## {{ site.data.dungeon.sbg.sadana_bloodfury }} trash
+### {{ site.data.dungeon.sbg.sadana_bloodfury }} trash
 
 **{{ site.data.dungeon.sbg.shadowmoon_bone_mender }}**
 * Use {{ site.data.spell.wind_shear }} to interrupt {{ site.data.dungeon.sbg.shadow_mend }} in priority and {{ site.data.dungeon.sbg.shadow_bolt }} with extra kicks.
@@ -699,18 +702,18 @@ to quickly leave the AoE.  Use {{ site.data.talent.swg }} to keep uptime while g
 * Get away from them when they teleport on you and cast {{ site.data.dungeon.sbg.cry_of_anguish }}.
 * Stay near the group so that they don't teleport too far.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-## {{ site.data.dungeon.sbg.sadana_bloodfury }}
+### {{ site.data.dungeon.sbg.sadana_bloodfury }}
 
 * Stay packed with your group to bait {{ site.data.dungeon.sbg.daggerfall }} in the same area.
 * Use {{ site.data.talent.ag }} to help healing the damage of {{ site.data.dungeon.sbg.whispers_of_the_dark_star }}. Use {{ site.data.talent.as }} to help yourself if needed.
 * Immediately switch on the Defiled Soul when {{ site.data.dungeon.sbg.dark_communion_sbg }} starts. Remember to use {{ site.data.spell.fs }} on both targets. It's a good moment to gain extra value from {{ site.data.talent.splinter }}.
 * Enter a {{ site.data.dungeon.sbg.lunar_purity }} rune to reduce the damage of {{ site.data.dungeon.sbg.dark_eclipse }}.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-## {{ site.data.dungeon.sbg.nhallish }} trash
+### {{ site.data.dungeon.sbg.nhallish }} trash
 
 **{{ site.data.dungeon.sbg.shadowmoon_dominator }}**
 * Try to not interrupt their initial {{ site.data.dungeon.sbg.domination }} cast as it will prevent them from casting anything else. While the initial cast is still going, {{ site.data.dungeon.sbg.subjugated_soul }} will do bonus damage and potentially target random players. Interrupt the cast with {{ site.data.spell.wind_shear }} as needed before anyone dies.
@@ -724,18 +727,18 @@ to quickly leave the AoE.  Use {{ site.data.talent.swg }} to keep uptime while g
 * Use {{ site.data.talent.purge }} to dispel {{ site.data.dungeon.sbg.incorporeal }}.
 * {{ site.data.dungeon.sbg.death_blast }} will one-shot a party member in higher keys. It's a must interrupt !!
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-## {{ site.data.dungeon.sbg.nhallish }}
+### {{ site.data.dungeon.sbg.nhallish }}
 
 * Move away from {{ site.data.dungeon.sbg.nhallish }} after it uses {{ site.data.dungeon.sbg.planar_shift }} as it will cast {{ site.data.dungeon.sbg.void_vortex }} right after.
 * Dodge the purple swirlies from {{ site.data.dungeon.sbg.void_devastation }}. Remember to use {{ site.data.talent.swg }} to keep uptime while moving.
 * During {{ site.data.dungeon.sbg.soul_steal }}, you will be separated from your healer and take moderate damage. Use {{ site.data.talent.as }} and {{ site.data.item.potion_rhp }} as needed.
 * Use offensive CDs when you get the {{ site.data.dungeon.sbg.returned_soul }} buff after {{ site.data.dungeon.sbg.soul_steal }}.  If it's available, wait for your whole group to be back before using {{ site.data.spell.bl }}.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-## {{ site.data.dungeon.sbg.bonemaw }} trash
+### {{ site.data.dungeon.sbg.bonemaw }} trash
 
 **{{ site.data.dungeon.sbg.monstrous_corpse_spider }}**
 * Use {{ site.data.spell.wind_shear }} to interrupt {{ site.data.dungeon.sbg.necrotic_burst }}.
@@ -747,25 +750,25 @@ to quickly leave the AoE.  Use {{ site.data.talent.swg }} to keep uptime while g
 * They will disappear at 20% health, don't use CDs at a bad timing.
 * Dodge {{ site.data.dungeon.sbg.body_slam }}. Use {{ site.data.talent.swg }} if needed.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-## {{ site.data.dungeon.sbg.bonemaw }}
+### {{ site.data.dungeon.sbg.bonemaw }}
 
 * Stay close to the boss to bait {{ site.data.dungeon.sbg.necrotic_pitch }} near melee.
 * Stand in {{ site.data.dungeon.sbg.necrotic_pitch }} during {{ site.data.dungeon.sbg.inhale }}.
 * Beware of the additional {{ site.data.dungeon.sbg.body_slam }} coming from behind after the first {{ site.data.dungeon.sbg.inhale }}.
 * Use {{ site.data.spell.fs }} on all three targets when the {{ site.data.dungeon.sbg.carrion_worm }} come back. Try to use them for {{ site.data.talent.splinter }} value.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-## {{ site.data.dungeon.sbg.nerzhul }}'s Elementals
+### {{ site.data.dungeon.sbg.nerzhul }}'s Elementals
 
 * The pack before {{ site.data.dungeon.sbg.nerzhul }} consists of two {{ site.data.dungeon.sbg.void_spawn }}, making it super deadly. You need to Line of Sight at least one of the {{ site.data.dungeon.sbg.void_pulse }} or you will likely die. You can do it either with the door at the entrance or with the altars on the side, which have small corners to hide.
 * Use everything at your disposal to survive : {{ site.data.talent.as }}, {{ site.data.talent.ee }}, {{ site.data.talent.ag }}, {{ site.data.item.potion_rhp }}.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-## {{ site.data.dungeon.sbg.nerzhul }}
+### {{ site.data.dungeon.sbg.nerzhul }}
 
 * {{ site.data.dungeon.sbg.nerzhul }} is a movement heavy fight that can be quite draining.
 * As ranged, you need to stay far away from the boss to bait {{ site.data.dungeon.sbg.omen_of_death }}.
@@ -786,20 +789,14 @@ to quickly leave the AoE.  Use {{ site.data.talent.swg }} to keep uptime while g
 <div id="tjs-collapse" class="collapse" aria-labelledby="tjs" data-parent="#accordion">
 <div class="card-body" markdown="1">
 
-## Talents
-
 ### Notable Talent Choices
-* {{ site.data.talent.cleanse_spirit }} is a mandatory talent in Temple of the Jade Serpent, unless you have a curse dispel in your group.
-* {{ site.data.talent.tremor_totem }} has some uses but it isn't mandatory at all.
+* {{ site.data.talent.cleanse_spirit }} is a mandatory talent in Temple of the Jade Serpent.
+* {{ site.data.talent.tremor_totem }} has some uses, notably to counter the fear sha if people do not kick, but it could be skipped.
+* {{ site.data.talent.purge }} has can be used a single time in the dungeon. Probably the best moment to drop it.
 
-### Wildfire
-<div class="iframe-holder">
-<iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAg0SrJJtkAJINKRLtkQOAAAAAAgSASJJRIBSLJppECCRAC?width=530&level=70" frameborder="0" width="530px" height="100%"></iframe>
-</div>
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
-
-## {{ site.data.dungeon.tjs.wise_mari }} trash
+### {{ site.data.dungeon.tjs.wise_mari }} trash
 
 **{{ site.data.dungeon.tjs.fallen_waterspeaker }}**
 * Use {{ site.data.spell.wind_shear }} to interrupt {{ site.data.dungeon.tjs.tidal_burst }} and {{ site.data.dungeon.tjs.hydrolance }}.
@@ -808,17 +805,17 @@ to quickly leave the AoE.  Use {{ site.data.talent.swg }} to keep uptime while g
 * Get out of the huge {{ site.data.dungeon.tjs.surging_deluge }} blue swirly.
 * Try to line of sight {{ site.data.dungeon.tjs.tainted_ripple }}. Use {{ site.data.talent.as }} if you get the debuff. Use {{ site.data.talent.ag }} to help your party member if any get the debuff.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-## {{ site.data.dungeon.tjs.wise_mari }}
+### {{ site.data.dungeon.tjs.wise_mari }}
 
 * Stay far away from the boss to easily drop {{ site.data.dungeon.tjs.corrupted_vortex }}. Use {{ site.data.talent.as }} as needed when dropping it.
 * Move around the boss to dodge {{ site.data.dungeon.tjs.wash_away }}. Use {{ site.data.talent.swg }} to keep uptime while moving.
 * Time your movement to avoid the pulsing water from {{ site.data.dungeon.tjs.corrupted_geyser }}. [This weekaura](https://wago.io/RaFUBlICM) (by Absence) will tell you when {{ site.data.dungeon.tjs.corrupted_geyser }} will burst.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-## {{ site.data.dungeon.tjs.strife }} and {{ site.data.dungeon.tjs.peril }} trash
+### {{ site.data.dungeon.tjs.strife }} and {{ site.data.dungeon.tjs.peril }} trash
 
 **{{ site.data.dungeon.tjs.haunting_sha }}**
 * Don't be on the tank, {{ site.data.dungeon.tjs.haunting_gaze }} cleaves.
@@ -847,18 +844,18 @@ to quickly leave the AoE.  Use {{ site.data.talent.swg }} to keep uptime while g
 * Use {{ site.data.spell.wind_shear }} to interrupt {{ site.data.dungeon.tjs.cat_nap }}.
 * Use {{ site.data.talent.as }} if you get targeted by {{ site.data.dungeon.tjs.savage_leap }}.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-## {{ site.data.dungeon.tjs.strife }} and {{ site.data.dungeon.tjs.peril }}
+### {{ site.data.dungeon.tjs.strife }} and {{ site.data.dungeon.tjs.peril }}
 
 * Stay in melee for healing purposes.
 * Have {{ site.data.spell.fs }} up on both bosses but focus one boss at a time.
 * Switch between {{ site.data.dungeon.tjs.strife }} and {{ site.data.dungeon.tjs.peril }} when {{ site.data.dungeon.tjs.intensity }} reaches 7 stacks.
 * {{ site.data.dungeon.tjs.feeling_of_superiority }} is a damage buff received randomly that can be exchanged by going on the current wearer of the buff. Use {{ site.data.talent.as }} when at high stack of {{ site.data.dungeon.tjs.feeling_of_superiority }}.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-## {{ site.data.dungeon.tjs.liu_flameheart }} trash
+### {{ site.data.dungeon.tjs.liu_flameheart }} trash
 
 **{{ site.data.dungeon.tjs.shambling_infester }}**
 * It will periodically summon {{ site.data.dungeon.tjs.lesser_sha }} with {{ site.data.dungeon.tjs.summon_sha }}. As before, beware of their {{ site.data.dungeon.tjs.sha_eruption }} on death.
@@ -874,24 +871,24 @@ to quickly leave the AoE.  Use {{ site.data.talent.swg }} to keep uptime while g
 **{{ site.data.dungeon.tjs.minion_of_doubt }}**
 * Dodge the {{ site.data.dungeon.tjs.shattered_resolve }} black swirlies. Use {{ site.data.talent.cleanse_spirit }} to remove the curse it casts on anyone touched.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-## {{ site.data.dungeon.tjs.liu_flameheart }}
+### {{ site.data.dungeon.tjs.liu_flameheart }}
 
 * Keep offensive CDs for phase 2 (at 70%).
 * Dodge the wave of flames from {{ site.data.dungeon.tjs.serpent_kick }} and {{ site.data.dungeon.tjs.jade_serpent_kick }}. Stop casting if you have to. Use {{ site.data.talent.swg }} as needed.
 * Don't be in front of the boss when she takes {{ site.data.dungeon.tjs.yulon }}'s form to passively dodge {{ site.data.dungeon.tjs.jade_fire_breath }}.
 * Dodge the green {{ site.data.dungeon.tjs.jade_fire }} swirly.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-## {{ site.data.dungeon.tjs.sha_of_doubt }} trash
+### {{ site.data.dungeon.tjs.sha_of_doubt }} trash
 
 The mobs before the last boss were all already present in the dungeon so they don't need additional explanations. The packs are nonetheless really difficult because of the mobs arrangement. They notably require a lot of interrupt and have many deadly mechanics. In {{ site.data.affixes.fortified }} weeks, you might want to keep {{ site.data.spell.bl }} for the last pack of the dungeon.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-## {{ site.data.dungeon.tjs.sha_of_doubt }}
+### {{ site.data.dungeon.tjs.sha_of_doubt }}
 
 * Be ready to use {{ site.data.talent.as }} and {{ site.data.item.potion_rhp }} if your healer didn't dispel {{ site.data.dungeon.tjs.touch_of_nothingness }} on you first.
 * Stack with your group near a wall during {{ site.data.dungeon.tjs.bounds_of_reality }} to spawn all {{ site.data.dungeon.tjs.figment_of_doubt }} in the same area. CC, kite and burst them to quickly go out of this phase.
@@ -907,20 +904,14 @@ The mobs before the last boss were all already present in the dungeon so they do
 <div id="av-collapse" class="collapse" aria-labelledby="av" data-parent="#accordion">
 <div class="card-body" markdown="1">
 
-## Talents
-
 ### Notable Talent Choices
-* {{ site.data.talent.thunderous_paws }} and {{ site.data.talent.gust_of_wind }} are quite useful in The Azure Vault.
+* {{ site.data.talent.thunderous_paws }} is really useful to reset the slow on the last boss
+* {{ site.data.talent.gust_of_wind }} gives you extra mobility in the long corridors of the dungeon and allows you to execute the jump down skips without dying.
 * {{ site.data.talent.tremor_totem }} can make some packs less heavy on interrupt requirements but it isn't mandatory at all.
 
-### Wildfire
-<div class="iframe-holder">
-<iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAg0SrJJtkAJINKRLtkQOAAAAAAgSASJJKpJg0SSaKhgQEgA?width=530&level=70" frameborder="0" width="530px" height="100%"></iframe>
-</div>
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
-
-## {{ site.data.dungeon.av.leymor }} trash
+### {{ site.data.dungeon.av.leymor }} trash
 
 **{{ site.data.dungeon.av.conjured_lasher }}**
 * Use {{ site.data.spell.wind_shear }} to interrupt {{ site.data.dungeon.av.mystic_vapors }}.
@@ -932,18 +923,18 @@ The mobs before the last boss were all already present in the dungeon so they do
 * Use {{ site.data.spell.wind_shear }} to interrupt {{ site.data.dungeon.av.erratic_growth }}.
 * Dodge {{ site.data.dungeon.av.wild_eruption }} purple swirlies and puddles. Use {{ site.data.talent.swg }} to keep uptime while moving.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-## {{ site.data.dungeon.av.leymor }}
+### {{ site.data.dungeon.av.leymor }}
 
 * Stay spreaded in range and dodge {{ site.data.dungeon.av.ley_line_sprouts }}. You must use {{ site.data.dungeon.av.leymor }}'s other abilities to destroy them.
 * {{ site.data.dungeon.av.explosive_brand }} will knock you back and allow you transform nearby {{ site.data.dungeon.av.ley_line_sprouts }} into {{ site.data.dungeon.av.bubbling_sapling }}. Spread with your group to destroy as many as you can.
 * {{ site.data.dungeon.av.erupting_fissure }} is a frontal on the tank that will transform {{ site.data.dungeon.av.ley_line_sprouts }} into {{ site.data.dungeon.av.bubbling_sapling }}. Don't be on him.
 * {{ site.data.dungeon.av.consuming_stomp }} will deal huge damage, increased by the number of {{ site.data.dungeon.av.ley_line_sprouts }} active. Use {{ site.data.talent.as }} and {{ site.data.talent.ag }} as needed.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-## {{ site.data.dungeon.av.azureblade }} trash
+### {{ site.data.dungeon.av.azureblade }} trash
 
 **{{ site.data.dungeon.av.arcane_elemental }}**
 * Use {{ site.data.spell.wind_shear }} to interrupt {{ site.data.dungeon.av.waking_bane }} in priority and {{ site.data.dungeon.av.arcane_bolt }} if possible.
@@ -972,9 +963,9 @@ The mobs before the last boss were all already present in the dungeon so they do
 **{{ site.data.dungeon.av.scalebane_lieutenant }}**
 * Don't be on the tank, {{ site.data.dungeon.av.spellfrost_breath }} cleaves.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-## {{ site.data.dungeon.av.azureblade }}
+### {{ site.data.dungeon.av.azureblade }}
 
 * There will a decent number of {{ site.data.dungeon.av.draconic_image }} that will spawn during the fight. Try to have {{ site.data.spell.fs }} on all targets at all time.
 * Dodge the swirlies creates on death by the {{ site.data.dungeon.av.draconic_image }}. But keep {{ site.data.talent.swg }} for the transition.
@@ -984,9 +975,9 @@ The mobs before the last boss were all already present in the dungeon so they do
 * During {{ site.data.dungeon.av.overwhelming_energy }}, use {{ site.data.talent.swg }} to dodge the {{ site.data.dungeon.av.ancient_orb }} and burst the {{ site.data.dungeon.av.draconic_image }} as fast as possible.
 * Use offensive and defensive CDs during {{ site.data.dungeon.av.overwhelming_energy }}, this phase is the hardest by far.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-## {{ site.data.dungeon.av.telash_greywing }} trash
+### {{ site.data.dungeon.av.telash_greywing }} trash
 
 **{{ site.data.dungeon.av.drakonid_breaker }}**
 * {{ site.data.dungeon.av.shoulder_slam }} will knock you back. Be careful about your position at all time.
@@ -995,18 +986,18 @@ The mobs before the last boss were all already present in the dungeon so they do
 **{{ site.data.dungeon.av.nullmagic_hornswog }}**
 * {{ site.data.dungeon.av.null_stomp }} will make them jump to a random location, typically preferring to jump to farther players. Stay close melee as much as possible.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-## {{ site.data.dungeon.av.telash_greywing }}
+### {{ site.data.dungeon.av.telash_greywing }}
 
 * Do not use CDs at the start of the battle, the boss will go immune after ~20 seconds.
 * {{ site.data.dungeon.av.frost_bomb }} will require players to spread and let space for the group to move after it drops. Use {{ site.data.talent.gust_of_wind }} to quickly go out of the patch of ice. Use {{ site.data.talent.swg }} to keep uptime.
 * Hide inside of a {{ site.data.dungeon.av.vault_rune }} during {{ site.data.dungeon.av.absolute_zero }}.
 * You should already be spreaded for {{ site.data.dungeon.av.icy_devastator }}, just use {{ site.data.talent.as }} if you are targeted.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-## {{ site.data.dungeon.av.umbrelskul }}
+### {{ site.data.dungeon.av.umbrelskul }}
 
 * Try to stay still as much as possible to avoid gaining stacks of {{ site.data.dungeon.av.oppressive_miasma }}. Use {{ site.data.talent.gust_of_wind }} if you need to quickly move and {{ site.data.talent.thunderous_paws }} to reset your stacks.
 * {{ site.data.dungeon.av.arcane_eruption }} will cause swirlies around the room and create {{ site.data.dungeon.av.crackling_vortex }} that will slowly move towards players that can generate healing aggro.
@@ -1025,20 +1016,14 @@ The mobs before the last boss were all already present in the dungeon so they do
 <div id="no-collapse" class="collapse" aria-labelledby="no" data-parent="#accordion">
 <div class="card-body" markdown="1">
 
-## Talents
-
 ### Notable Talent Choices
 * {{ site.data.talent.tremor_totem }} has some uses on the third boss but it isn't mandatory at all.
 * {{ site.data.talent.purge }} is very useful on the second boss, be sure to talent it if your group doesn't have one.
+* {{ site.data.talent.stoneskin_totem }} can be used in higher key for {{ site.data.dungeon.no.teera }}'s {{ site.data.dungeon.no.quick_shot }} and {{ site.data.dungeon.no.balakar_khan }}'s {{ site.data.dungeon.no.iron_spear }}.
 
-### Wildfire
-<div class="iframe-holder">
-<iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAg0SrJJtkAJINKRLtkQOAAAAAAgSASJJRaiCSLSaKhgQEgA?width=530&level=70" frameborder="0" width="530px" height="100%"></iframe>
-</div>
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
-
-## {{ site.data.dungeon.no.granyth }} trash
+### {{ site.data.dungeon.no.granyth }} trash
 **{{ site.data.dungeon.no.nokhud_longbow }}**
 * Watch your feet to dodge {{ site.data.dungeon.no.rain_of_arrows }}. Use {{ site.data.talent.swg }} to keep uptime while dodging.
 
@@ -1054,9 +1039,9 @@ The mobs before the last boss were all already present in the dungeon so they do
 * Use {{ site.data.spell.wind_shear }} to interrupt {{ site.data.dungeon.no.disruptive_shout }}, stop casting if the cast is going through or you will be spell locked.
 * Stay farther than 8 yards away to ignore {{ site.data.dungeon.no.war_stomp }}.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-## {{ site.data.dungeon.no.granyth }}
+### {{ site.data.dungeon.no.granyth }}
 * Have {{ site.data.spell.fs }} on all targets at all time.
 * Switch on {{ site.data.dungeon.no.nokhud_saboteur }} as soon as it spawn. Use {{ site.data.spell.earthbind_totem }} and {{ site.data.talent.capacitor_totem }} to disrupt it. Do not let him cast {{ site.data.dungeon.no.dismantle }}.
 * {{ site.data.dungeon.no.shards_of_stone }} does a lot of party damage. Use {{ site.data.talent.as }} to mitigate and {{ site.data.talent.ag }} to heal the damage.
@@ -1065,9 +1050,9 @@ The mobs before the last boss were all already present in the dungeon so they do
 
 *Note:* Using {{ site.data.dungeon.no.dragonkiller_lance }} early will prevent the second {{ site.data.dungeon.no.shards_of_stone }} and reduce party damage by a lot.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-## {{ site.data.dungeon.no.the_raging_tempest }} trash
+### {{ site.data.dungeon.no.the_raging_tempest }} trash
 
 **{{ site.data.dungeon.no.primalist_stormspeaker }}**
 * Always interrupt {{ site.data.dungeon.no.tempest }}. Assign a player to always and only kick it.
@@ -1087,9 +1072,9 @@ The mobs before the last boss were all already present in the dungeon so they do
 * {{ site.data.dungeon.no.totemic_overload }} will deal party-wide damage and a few {{ site.data.dungeon.no.uncontrollable_energy }} will spawn. Step on the lightning orbs to get a 5% damage increase stacking.
 * Use {{ site.data.spell.wind_shear }} to interrupt {{ site.data.dungeon.no.stormbolt }} if you are not kicking {{ site.data.dungeon.no.tempest }}.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-## {{ site.data.dungeon.no.the_raging_tempest }}
+### {{ site.data.dungeon.no.the_raging_tempest }}
 * Use {{ site.data.talent.purge }} to dispel {{ site.data.dungeon.no.energy_surge }}.
 * You can have up to 10 stacks of {{ site.data.dungeon.no.uncontrollable_energy }}. Stack them as fast as possible then try to keep one orb to refresh the buff as late as possible. **Never** let a {{ site.data.dungeon.no.uncontrollable_energy }} reach the boss.
 * Stay spreaded at 12 yards away to not cleave your party with {{ site.data.dungeon.no.lightning_strike }}.
@@ -1097,9 +1082,9 @@ The mobs before the last boss were all already present in the dungeon so they do
 * Use {{ site.data.talent.as }} and {{ site.data.talent.ag }} to survive {{ site.data.dungeon.no.electrical_storm }}.
 * Don't go under the boss or {{ site.data.dungeon.no.the_raging_tempest_aoe }} will kill you.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-## {{ site.data.dungeon.no.teera }} and {{ site.data.dungeon.no.maruuk }} trash
+### {{ site.data.dungeon.no.teera }} and {{ site.data.dungeon.no.maruuk }} trash
 
 **{{ site.data.dungeon.no.ukhel_deathspeaker }}**
 * Stay farther than 10 yards away to ignore {{ site.data.dungeon.no.chant_of_the_dead }}.
@@ -1122,9 +1107,9 @@ The mobs before the last boss were all already present in the dungeon so they do
 * Use {{ site.data.spell.wind_shear }} to interrupt {{ site.data.dungeon.no.death_bolt_volley }}. Assign a player to them if you have to.
 * Pick up your sould when targeted by {{ site.data.dungeon.no.shatter_soul }}. Use {{ site.data.talent.swg }} to keep uptime while doing it.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-## {{ site.data.dungeon.no.teera }} and {{ site.data.dungeon.no.maruuk }}
+### {{ site.data.dungeon.no.teera }} and {{ site.data.dungeon.no.maruuk }}
 * Have {{ site.data.spell.fs }} up on both bosses at all times.
 * {{ site.data.dungeon.no.teera }} will reloacate with {{ site.data.dungeon.no.spirit_leap }}. {{ site.data.dungeon.no.spirit_leap }} doesn't do damage, do not move to dodge it.
 * Stack up with your party when dropping {{ site.data.dungeon.no.gale_arrow }}. You won't take damage from other player's tornadoes on the initial hit and it becomes easy to dodge the tornadoes as they come back. You can either stack in melee or do a ranged and a melee group.
@@ -1132,9 +1117,9 @@ The mobs before the last boss were all already present in the dungeon so they do
 * Get ready to instantly use {{ site.data.spell.wind_shear }} to interrupt {{ site.data.dungeon.no.guardian_wind }} right after {{ site.data.dungeon.no.repel }}.
 * Dodge the brown swirlies during {{ site.data.dungeon.no.earthsplitter }}. Use {{ site.data.talent.swg }} to keep uptime while dodging.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-## {{ site.data.dungeon.no.balakar_khan }} trash
+### {{ site.data.dungeon.no.balakar_khan }} trash
 
 A common route skip most of the trash in Nokhudon Hold, as they are very inneficient. You can find this route [here](https://youtu.be/0tIJAU-qA4M).
 
@@ -1145,9 +1130,9 @@ A common route skip most of the trash in Nokhudon Hold, as they are very innefic
 * Dodge {{ site.data.dungeon.no.vehement_charge }}.
 * Don't be on the tank, {{ site.data.dungeon.no.broad_stomp }} is a frontal on him.
 
-![Line Break](/assets/img/blog/bluelinebreak.png)
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
 
-## {{ site.data.dungeon.no.balakar_khan }}
+### {{ site.data.dungeon.no.balakar_khan }}
 ### Phase 1
 * When focused by {{ site.data.dungeon.no.iron_spear }}, be a bit away from the boss and use {{ site.data.talent.as }} if needed. Move as soon as the spear hits you to dodge {{ site.data.dungeon.no.iron_stampede }}.
 * Dodge the {{ site.data.dungeon.no.upheaval }} frontal.
@@ -1169,8 +1154,12 @@ A common route skip most of the trash in Nokhudon Hold, as they are very innefic
 </div>
 </div>
 </div>
+</div>
+</div>
 
-<div class="card-body" markdown="1">
+<br>
+
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png" width="130%"/></p>
 
 # Useful WeakAuras
 
@@ -1180,10 +1169,11 @@ A common route skip most of the trash in Nokhudon Hold, as they are very innefic
 * [Mythic+ Auto Marker](https://wago.io/1ctv3b91K) by Megawatt
 * [Mythic+ Timer](https://wago.io/M+Timer) by Reloe
 
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png" width="130%"/></p>
+
 # Additional Resources
 
 * [Wowhead Elemental Shaman Mythic+ Guide](https://www.wowhead.com/guide/classes/shaman/elemental/mythic-plus-dungeon-tips) by HawkCorrigan
 * [Icy-Veins Elemental Shaman Mythic+ Tips](https://www.icy-veins.com/wow/elemental-shaman-pve-dps-mythic-plus-tips) by Stormy
 * [Mythic+ Subcreation](https://mplus.subcreation.net/elemental-shaman.html)
 * [Mythic+ Murlok.io](https://murlok.io/shaman/elemental/mm+)
-</div>

--- a/guide/mythic_plus/DF_season_1.md
+++ b/guide/mythic_plus/DF_season_1.md
@@ -23,7 +23,7 @@ Information on this page is written with the assumption that you understand the 
 
 This guide is intended to help you identify critical mobs and abilities as well as improve your mechanical literacy in using your toolkit as an Elemental Shaman in each dungeon. If you have suggestions to improve the information in this guide please contact Eokira#7823 using the [Earthshrine Elemental channel](https://discord.gg/pGkPDzh7rP) or the [Storm, Earth & Lava discord](https://discord.gg/y5dUf3PWrU).
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png" width="130%"/></p>
+<hr>
 
 # Talents
 
@@ -69,7 +69,7 @@ When pushing in higher keys, some talents become mandatory to survive:
 
 *Note: Again, these become mandatory only in higher keys and can be skipped when you are not in the hardest version of m+.*
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png" width="130%"/></p>
+<hr>
 
 # Miscellaneous Tips
 
@@ -95,7 +95,7 @@ When pushing in higher keys, some talents become mandatory to survive:
 
 * [Learn to log your dungeon runs!](https://www.warcraftlogs.com/help/start) Warcraft Logs filters dungeons with pull-by-pull analyses and records replays of dungeon runs. Having logs available to share is helpful for you to receive actionable feedback.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png" width="130%"/></p>
+<hr>
 
 # Affixes
 
@@ -141,7 +141,7 @@ The affixes {{ site.data.affixes.necrotic }} and {{ site.data.affixes.inspiring 
 * During high stress situation, it might be best to clear the marks as soon as possible to avoid bad overlaps.
 * When running back after dying, consider waiting a bit before entering the 100 yards range of your party if they are still in battle. If you have the debuff on you, you would most likely kill your party and yourself.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png" width="130%"/></p>
+<hr>
 
 # Dungeons
 
@@ -164,7 +164,7 @@ The affixes {{ site.data.affixes.necrotic }} and {{ site.data.affixes.inspiring 
 * {{ site.data.talent.purge }} has some uses in the area before the last boss.
 * {{ site.data.talent.stoneskin_totem }} can be used in higher key for {{ site.data.dungeon.aa.crawth }}'s {{ site.data.dungeon.aa.savage_peck }} and {{ site.data.dungeon.aa.overgrown_ancient }}'s {{ site.data.dungeon.aa.splinterbark }} and {{ site.data.dungeon.aa.barkbreaker }}.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### Dungeon buffs
 
@@ -173,7 +173,7 @@ The affixes {{ site.data.affixes.necrotic }} and {{ site.data.affixes.inspiring 
 * {{ site.data.dungeon.aa.red_dragonfligh_pledge_pin }} is also an option in higher keys for survivability gain.
 * Do not pick {{ site.data.dungeon.aa.blue_dragonflight_pledge_pin }}. It gives rating and as such, it will be impacted by diminishing return.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.aa.vexamus }} trash
 
@@ -190,7 +190,7 @@ The affixes {{ site.data.affixes.necrotic }} and {{ site.data.affixes.inspiring 
 **{{ site.data.dungeon.aa.arcane_ravager }}**
 * {{ site.data.dungeon.aa.arcane_ravager }} will jump on a random player with {{ site.data.dungeon.aa.vicious_ambush }} and cast a {{ site.data.dungeon.aa.riftbreath }} frontal. Beware of it at all times and use {{ site.data.talent.swg }} to reposition as needed.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.aa.vexamus }}
 
@@ -198,7 +198,7 @@ The affixes {{ site.data.affixes.necrotic }} and {{ site.data.affixes.inspiring 
 * Spread with {{ site.data.dungeon.aa.mana_bombs }} and try to drop pools along the walls.
 * Beware of {{ site.data.dungeon.aa.arcane_fissure }}, it does a lot of direct damage. Use {{ site.data.talent.as }} as needed. {{ site.data.talent.swg }} will allow you to keep uptime while dodging the swirlies.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.aa.crawth }} trash
 
@@ -211,7 +211,7 @@ The affixes {{ site.data.affixes.necrotic }} and {{ site.data.affixes.inspiring 
 * Use {{ site.data.spell.wind_shear }} to interrupt {{ site.data.dungeon.aa.call_of_the_flock }}.
 * Dodge the {{ site.data.dungeon.aa.gust }} frontal.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.aa.crawth }}
 
@@ -221,7 +221,7 @@ The affixes {{ site.data.affixes.necrotic }} and {{ site.data.affixes.inspiring 
 * Pick up wind orbs for 45% haste and a "cast while moving" buff for 20s. Do not overlap the orb buff with {{ site.data.talent.swg }}.
 * Try to be at full health before {{ site.data.dungeon.aa.deafening_screech }} or use {{ site.data.talent.as }}, especially at high {{ site.data.dungeon.aa.sonic_vulnerability }} stacks.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.aa.overgrown_ancient }} trash
 
@@ -235,7 +235,7 @@ The affixes {{ site.data.affixes.necrotic }} and {{ site.data.affixes.inspiring 
 * These mobs will charge on you with {{ site.data.dungeon.aa.darting_sting }}, do not be at max range to keep them near melees for uptime.
 * Consider using {{ site.data.talent.as }} at low health.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.aa.overgrown_ancient }}
 
@@ -246,7 +246,7 @@ The affixes {{ site.data.affixes.necrotic }} and {{ site.data.affixes.inspiring 
 * Hard switch on the {{ site.data.dungeon.aa.ancient_branch }} whenever it spawns.
 * Use {{ site.data.spell.wind_shear }} to interrupt {{ site.data.dungeon.aa.healing_touch }} from {{ site.data.dungeon.aa.ancient_branch }}.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.aa.echo_of_doragosa }} trash
 
@@ -260,7 +260,7 @@ The affixes {{ site.data.affixes.necrotic }} and {{ site.data.affixes.inspiring 
 **{{ site.data.dungeon.aa.ethereal_restorer }}**
 * Use {{ site.data.talent.purge }} to dispel {{ site.data.dungeon.aa.celestial_shield }} as soon as possible.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.aa.echo_of_doragosa }}
 
@@ -289,7 +289,7 @@ The affixes {{ site.data.affixes.necrotic }} and {{ site.data.affixes.inspiring 
 * {{ site.data.talent.guardians_cudgel }} and {{ site.data.talent.thunderstorm }} are very good hard CC to deal with the {{ site.data.dungeon.cos.blazing_imp }} packs.
 * {{ site.data.talent.stoneskin_totem }} can be used in higher key for {{ site.data.dungeon.cos.imacutya }}'s damage on the tank and {{ site.data.dungeon.cos.advisor_melandrus }}'s {{ site.data.dungeon.cos.slicing_maelstrom }}.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.cos.patrol_captain_gerdo }} trash
 
@@ -317,7 +317,7 @@ The affixes {{ site.data.affixes.necrotic }} and {{ site.data.affixes.inspiring 
 **{{ site.data.dungeon.cos.arcane_manifestation }}**
 * Use {{ site.data.spell.wind_shear }} to interrupt {{ site.data.dungeon.cos.drain_magic }}.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.cos.patrol_captain_gerdo }}
 
@@ -328,7 +328,7 @@ The affixes {{ site.data.affixes.necrotic }} and {{ site.data.affixes.inspiring 
 * {{ site.data.dungeon.cos.streetsweeper }} will spawn orbs that do damage in a line after 3 seconds. Beware of {{ site.data.dungeon.cos.arcane_lockdown }} potentially slowing you.
 * Stay farther than 20 yards away to ignore {{ site.data.dungeon.cos.resonant_slash }}.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### Dungeon Buffs
 
@@ -336,7 +336,7 @@ The area before the second boss is full of items that players can interact with 
 Shamans can interact with the {{ site.data.dungeon.cos.waterlogged_scroll }} that is accessible near the fountain to give 35% movement speed to their party.
 You can find a complete list of all of the accessible items and buff on [this link](https://www.wowhead.com/guide/mythic-plus-dungeons/court-of-stars-strategy#overview-dungeon-buffs).
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.cos.talixae_flamewreath }} trash
 
@@ -370,7 +370,7 @@ You can find a complete list of all of the accessible items and buff on [this li
 **{{ site.data.dungeon.cos.jazshariu }}**
 * Dodge the {{ site.data.dungeon.cos.crushing_leap_cos }} swirlies and the following {{ site.data.dungeon.cos.shockwave }} frontal.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.cos.talixae_flamewreath }}
 
@@ -378,7 +378,7 @@ You can find a complete list of all of the accessible items and buff on [this li
 * You can solo kick {{ site.data.dungeon.cos.withering_soul }}! Notify your group to avoid over-kicking. Your party will have more kicks for the {{ site.data.dungeon.cos.blazing_imp }} if needed.
 * Dodge the {{ site.data.dungeon.cos.infernal_eruption }} swirlies then blast the group of {{ site.data.dungeon.cos.blazing_imp }}. Use {{ site.data.talent.capacitor_totem }} if they are about to cast.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### Hide and Seek minigame
 
@@ -389,7 +389,7 @@ Good luck for the mini-game ! Remember to pick up all of the clues, especially i
 * Use {{ site.data.spell.wind_shear }} to interrupt {{ site.data.dungeon.cos.shadow_bolt_volley }}.
 * Use {{ site.data.talent.capacitor_totem }} or {{ site.data.talent.hex }} to interrupt the {{ site.data.dungeon.cos.hypnosis_bat }} cast.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.cos.advisor_melandrus }}
 
@@ -422,7 +422,7 @@ Good luck for the mini-game ! Remember to pick up all of the clues, especially i
 * The bosses are pretty dangerous, notably in {{ site.data.affixes.tyrannical }}. Consider running {{ site.data.talent.spirit_wolf }} and {{ site.data.talent.brimming_with_life }} for extra survivability.
 * {{ site.data.talent.stoneskin_totem }} can be used in higher key for {{ site.data.dungeon.hov.hymdall }}'s {{ site.data.dungeon.hov.horn_of_valor }} and {{ site.data.dungeon.hov.fenryr }}'s {{ site.data.dungeon.hov.claw_frenzy }}.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.hov.hymdall }} trash
 
@@ -436,7 +436,7 @@ Good luck for the mini-game ! Remember to pick up all of the clues, especially i
 * Watch out for the {{ site.data.dungeon.hov.lightning_breath }} frontal.
 * Dodge the {{ site.data.dungeon.hov.crackling_storm }} swirly and the following tornado. Use {{ site.data.talent.swg }} to keep uptime while dodging.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.hov.hymdall }}
 
@@ -445,7 +445,7 @@ Good luck for the mini-game ! Remember to pick up all of the clues, especially i
 * {{ site.data.dungeon.hov.horn_of_valor }} will call 3 drakes that will fill with lightning the 3 sections of the room one after the other. Always pay attention to these drakes and move to the correct spot to dodge the {{ site.data.dungeon.hov.static_field }} and the following {{ site.data.dungeon.hov.ball_lightning }}. Use {{ site.data.talent.swg }} to keep uptime while dodging.
 * {{ site.data.dungeon.hov.horn_of_valor }} also does a lot of initial damage. Use {{ site.data.talent.as }} before it if you are not confident in your current HP.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.hov.hyrja }} trash
 
@@ -480,7 +480,7 @@ Good luck for the mini-game ! Remember to pick up all of the clues, especially i
 * Dodge the orbs of light during {{ site.data.dungeon.hov.sanctify }}. Use {{ site.data.talent.swg }} to keep uptime while dodging.
 * Use {{ site.data.spell.wind_shear }} to interrupt {{ site.data.dungeon.hov.searing_light }}.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.hov.hyrja }}
 
@@ -490,7 +490,7 @@ Good luck for the mini-game ! Remember to pick up all of the clues, especially i
 * Dodge the orbs of light during {{ site.data.dungeon.hov.sanctify }}. Use {{ site.data.talent.swg }} to keep uptime while dodging.
 * Don't be near your tank after {{ site.data.dungeon.hov.eye_of_the_storm }} and {{ site.data.dungeon.hov.sanctify }}, she will use {{ site.data.dungeon.hov.shield_of_light }}, a frontal beam on him.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.hov.fenryr }} trash
 
@@ -503,7 +503,7 @@ Good luck for the mini-game ! Remember to pick up all of the clues, especially i
 **{{ site.data.dungeon.hov.ebonclaw_worg }}**
 * These mobs are super deadly. They buff themselves while pulled together then jump on ranged players with {{ site.data.dungeon.hov.leap_for_the_throat }}. Stay close to melee but spreaded and use {{ site.data.talent.as }} as required.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.hov.fenryr }}
 
@@ -512,7 +512,7 @@ Good luck for the mini-game ! Remember to pick up all of the clues, especially i
 * Kite the boss if you are targeted by {{ site.data.dungeon.hov.scent_of_blood }}. Be careful not to run into the remaining {{ site.data.dungeon.hov.ebonclaw_worg }} in the area. Use {{ site.data.talent.swg }} to keep uptime while kiting.
 * Spread when targeted with {{ site.data.dungeon.hov.ravenous_leap }}. Quickly come back to help soak {{ site.data.dungeon.hov.claw_frenzy }}.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.hov.god_king_skovald }} trash
 
@@ -562,7 +562,7 @@ The 4 kings in the area must be defeated for {{ site.data.dungeon.hov.god_king_s
 * The bosses are pretty dangerous, notably in {{ site.data.affixes.tyrannical }}. Consider running {{ site.data.talent.spirit_wolf }} and {{ site.data.talent.brimming_with_life }} for extra survivability.
 * {{ site.data.talent.stoneskin_totem }} can be used in higher key to reduce tank damage on the second and third boss.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.rlp.melidrussa_chillworn }} trash
 
@@ -581,7 +581,7 @@ The 4 kings in the area must be defeated for {{ site.data.dungeon.hov.god_king_s
 * Dodge his {{ site.data.dungeon.rlp.blazing_rush }} charge on a random player. Don't make him charge into the eggs in the area or {{ site.data.dungeon.rlp.infused_whelp }} will spawn.
 * Dodge the red swirlies created by {{ site.data.dungeon.rlp.steel_barrage }}. Use {{ site.data.talent.swg }} to keep uptime while dodging.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.rlp.melidrussa_chillworn }}
 
@@ -591,7 +591,7 @@ to quickly leave the AoE.  Use {{ site.data.talent.swg }} to keep uptime while g
 * Use {{ site.data.talent.as }} and {{ site.data.talent.ag }} during {{ site.data.dungeon.rlp.frost_overload }} to survive. Use CDs to quickly burst her shield.
 * The {{ site.data.dungeon.rlp.infused_whelp }} that spawn are not a priority DPS, but it's important that they die so the tank doesn't get stunned by {{ site.data.dungeon.rlp.cold_claws }}. You can arrange with your group for a single person to do AoE and the other DPS to funnel damage into {{ site.data.dungeon.rlp.melidrussa_chillworn }}.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.rlp.kokia_blazehoof }} trash
 
@@ -616,7 +616,7 @@ to quickly leave the AoE.  Use {{ site.data.talent.swg }} to keep uptime while g
 * {{ site.data.dungeon.rlp.molten_blood }} does ramping damage starting at 50% HP. Use {{ site.data.talent.ag }} to help the healer below that threshold.
 * Use {{ site.data.talent.as }} as required.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.rlp.kokia_blazehoof }}
 
@@ -630,7 +630,7 @@ to quickly leave the AoE.  Use {{ site.data.talent.swg }} to keep uptime while g
 
 *Note:* Learning the timings to correctly bait the {{ site.data.dungeon.rlp.molten_boulder }} and {{ site.data.dungeon.rlp.ritual_of_blazebinding }} will make this fight significantly easier.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.rlp.kyrakka }} and {{ site.data.dungeon.rlp.erkhart_stormvein }} trash
 
@@ -655,7 +655,7 @@ to quickly leave the AoE.  Use {{ site.data.talent.swg }} to keep uptime while g
 * You want to use {{ site.data.talent.purge }} on {{ site.data.dungeon.rlp.primal_thundercloud }} **in priority** to remove as many {{ site.data.dungeon.rlp.tempest_barrier }} as possible.
 * Use {{ site.data.talent.ag }} and {{ site.data.talent.as }} to mitigate {{ site.data.dungeon.rlp.lightning_storm }}.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.rlp.kyrakka }} and {{ site.data.dungeon.rlp.erkhart_stormvein }}
 
@@ -683,7 +683,7 @@ to quickly leave the AoE.  Use {{ site.data.talent.swg }} to keep uptime while g
 * {{ site.data.talent.purge }} has some good uses, allowing you dispel big shields after the first boss notably.
 * {{ site.data.talent.tremor_totem }} can be used on the adds after the first boss.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.sbg.sadana_bloodfury }} trash
 
@@ -702,7 +702,7 @@ to quickly leave the AoE.  Use {{ site.data.talent.swg }} to keep uptime while g
 * Get away from them when they teleport on you and cast {{ site.data.dungeon.sbg.cry_of_anguish }}.
 * Stay near the group so that they don't teleport too far.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.sbg.sadana_bloodfury }}
 
@@ -711,7 +711,7 @@ to quickly leave the AoE.  Use {{ site.data.talent.swg }} to keep uptime while g
 * Immediately switch on the Defiled Soul when {{ site.data.dungeon.sbg.dark_communion_sbg }} starts. Remember to use {{ site.data.spell.fs }} on both targets. It's a good moment to gain extra value from {{ site.data.talent.splinter }}.
 * Enter a {{ site.data.dungeon.sbg.lunar_purity }} rune to reduce the damage of {{ site.data.dungeon.sbg.dark_eclipse }}.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.sbg.nhallish }} trash
 
@@ -727,7 +727,7 @@ to quickly leave the AoE.  Use {{ site.data.talent.swg }} to keep uptime while g
 * Use {{ site.data.talent.purge }} to dispel {{ site.data.dungeon.sbg.incorporeal }}.
 * {{ site.data.dungeon.sbg.death_blast }} will one-shot a party member in higher keys. It's a must interrupt !!
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.sbg.nhallish }}
 
@@ -736,7 +736,7 @@ to quickly leave the AoE.  Use {{ site.data.talent.swg }} to keep uptime while g
 * During {{ site.data.dungeon.sbg.soul_steal }}, you will be separated from your healer and take moderate damage. Use {{ site.data.talent.as }} and {{ site.data.item.potion_rhp }} as needed.
 * Use offensive CDs when you get the {{ site.data.dungeon.sbg.returned_soul }} buff after {{ site.data.dungeon.sbg.soul_steal }}.  If it's available, wait for your whole group to be back before using {{ site.data.spell.bl }}.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.sbg.bonemaw }} trash
 
@@ -750,7 +750,7 @@ to quickly leave the AoE.  Use {{ site.data.talent.swg }} to keep uptime while g
 * They will disappear at 20% health, don't use CDs at a bad timing.
 * Dodge {{ site.data.dungeon.sbg.body_slam }}. Use {{ site.data.talent.swg }} if needed.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.sbg.bonemaw }}
 
@@ -759,14 +759,14 @@ to quickly leave the AoE.  Use {{ site.data.talent.swg }} to keep uptime while g
 * Beware of the additional {{ site.data.dungeon.sbg.body_slam }} coming from behind after the first {{ site.data.dungeon.sbg.inhale }}.
 * Use {{ site.data.spell.fs }} on all three targets when the {{ site.data.dungeon.sbg.carrion_worm }} come back. Try to use them for {{ site.data.talent.splinter }} value.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.sbg.nerzhul }}'s Elementals
 
 * The pack before {{ site.data.dungeon.sbg.nerzhul }} consists of two {{ site.data.dungeon.sbg.void_spawn }}, making it super deadly. You need to Line of Sight at least one of the {{ site.data.dungeon.sbg.void_pulse }} or you will likely die. You can do it either with the door at the entrance or with the altars on the side, which have small corners to hide.
 * Use everything at your disposal to survive : {{ site.data.talent.as }}, {{ site.data.talent.ee }}, {{ site.data.talent.ag }}, {{ site.data.item.potion_rhp }}.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.sbg.nerzhul }}
 
@@ -794,7 +794,7 @@ to quickly leave the AoE.  Use {{ site.data.talent.swg }} to keep uptime while g
 * {{ site.data.talent.tremor_totem }} has some uses, notably to counter the fear sha if people do not kick, but it could be skipped.
 * {{ site.data.talent.purge }} has can be used a single time in the dungeon. Probably the best moment to drop it.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.tjs.wise_mari }} trash
 
@@ -805,7 +805,7 @@ to quickly leave the AoE.  Use {{ site.data.talent.swg }} to keep uptime while g
 * Get out of the huge {{ site.data.dungeon.tjs.surging_deluge }} blue swirly.
 * Try to line of sight {{ site.data.dungeon.tjs.tainted_ripple }}. Use {{ site.data.talent.as }} if you get the debuff. Use {{ site.data.talent.ag }} to help your party member if any get the debuff.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.tjs.wise_mari }}
 
@@ -813,7 +813,7 @@ to quickly leave the AoE.  Use {{ site.data.talent.swg }} to keep uptime while g
 * Move around the boss to dodge {{ site.data.dungeon.tjs.wash_away }}. Use {{ site.data.talent.swg }} to keep uptime while moving.
 * Time your movement to avoid the pulsing water from {{ site.data.dungeon.tjs.corrupted_geyser }}. [This weekaura](https://wago.io/RaFUBlICM) (by Absence) will tell you when {{ site.data.dungeon.tjs.corrupted_geyser }} will burst.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.tjs.strife }} and {{ site.data.dungeon.tjs.peril }} trash
 
@@ -844,7 +844,7 @@ to quickly leave the AoE.  Use {{ site.data.talent.swg }} to keep uptime while g
 * Use {{ site.data.spell.wind_shear }} to interrupt {{ site.data.dungeon.tjs.cat_nap }}.
 * Use {{ site.data.talent.as }} if you get targeted by {{ site.data.dungeon.tjs.savage_leap }}.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.tjs.strife }} and {{ site.data.dungeon.tjs.peril }}
 
@@ -853,7 +853,7 @@ to quickly leave the AoE.  Use {{ site.data.talent.swg }} to keep uptime while g
 * Switch between {{ site.data.dungeon.tjs.strife }} and {{ site.data.dungeon.tjs.peril }} when {{ site.data.dungeon.tjs.intensity }} reaches 7 stacks.
 * {{ site.data.dungeon.tjs.feeling_of_superiority }} is a damage buff received randomly that can be exchanged by going on the current wearer of the buff. Use {{ site.data.talent.as }} when at high stack of {{ site.data.dungeon.tjs.feeling_of_superiority }}.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.tjs.liu_flameheart }} trash
 
@@ -871,7 +871,7 @@ to quickly leave the AoE.  Use {{ site.data.talent.swg }} to keep uptime while g
 **{{ site.data.dungeon.tjs.minion_of_doubt }}**
 * Dodge the {{ site.data.dungeon.tjs.shattered_resolve }} black swirlies. Use {{ site.data.talent.cleanse_spirit }} to remove the curse it casts on anyone touched.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.tjs.liu_flameheart }}
 
@@ -880,13 +880,13 @@ to quickly leave the AoE.  Use {{ site.data.talent.swg }} to keep uptime while g
 * Don't be in front of the boss when she takes {{ site.data.dungeon.tjs.yulon }}'s form to passively dodge {{ site.data.dungeon.tjs.jade_fire_breath }}.
 * Dodge the green {{ site.data.dungeon.tjs.jade_fire }} swirly.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.tjs.sha_of_doubt }} trash
 
 The mobs before the last boss were all already present in the dungeon so they don't need additional explanations. The packs are nonetheless really difficult because of the mobs arrangement. They notably require a lot of interrupt and have many deadly mechanics. In {{ site.data.affixes.fortified }} weeks, you might want to keep {{ site.data.spell.bl }} for the last pack of the dungeon.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.tjs.sha_of_doubt }}
 
@@ -909,7 +909,7 @@ The mobs before the last boss were all already present in the dungeon so they do
 * {{ site.data.talent.gust_of_wind }} gives you extra mobility in the long corridors of the dungeon and allows you to execute the jump down skips without dying.
 * {{ site.data.talent.tremor_totem }} can make some packs less heavy on interrupt requirements but it isn't mandatory at all.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.av.leymor }} trash
 
@@ -923,7 +923,7 @@ The mobs before the last boss were all already present in the dungeon so they do
 * Use {{ site.data.spell.wind_shear }} to interrupt {{ site.data.dungeon.av.erratic_growth }}.
 * Dodge {{ site.data.dungeon.av.wild_eruption }} purple swirlies and puddles. Use {{ site.data.talent.swg }} to keep uptime while moving.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.av.leymor }}
 
@@ -932,7 +932,7 @@ The mobs before the last boss were all already present in the dungeon so they do
 * {{ site.data.dungeon.av.erupting_fissure }} is a frontal on the tank that will transform {{ site.data.dungeon.av.ley_line_sprouts }} into {{ site.data.dungeon.av.bubbling_sapling }}. Don't be on him.
 * {{ site.data.dungeon.av.consuming_stomp }} will deal huge damage, increased by the number of {{ site.data.dungeon.av.ley_line_sprouts }} active. Use {{ site.data.talent.as }} and {{ site.data.talent.ag }} as needed.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.av.azureblade }} trash
 
@@ -963,7 +963,7 @@ The mobs before the last boss were all already present in the dungeon so they do
 **{{ site.data.dungeon.av.scalebane_lieutenant }}**
 * Don't be on the tank, {{ site.data.dungeon.av.spellfrost_breath }} cleaves.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.av.azureblade }}
 
@@ -975,7 +975,7 @@ The mobs before the last boss were all already present in the dungeon so they do
 * During {{ site.data.dungeon.av.overwhelming_energy }}, use {{ site.data.talent.swg }} to dodge the {{ site.data.dungeon.av.ancient_orb }} and burst the {{ site.data.dungeon.av.draconic_image }} as fast as possible.
 * Use offensive and defensive CDs during {{ site.data.dungeon.av.overwhelming_energy }}, this phase is the hardest by far.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.av.telash_greywing }} trash
 
@@ -986,7 +986,7 @@ The mobs before the last boss were all already present in the dungeon so they do
 **{{ site.data.dungeon.av.nullmagic_hornswog }}**
 * {{ site.data.dungeon.av.null_stomp }} will make them jump to a random location, typically preferring to jump to farther players. Stay close melee as much as possible.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.av.telash_greywing }}
 
@@ -995,7 +995,7 @@ The mobs before the last boss were all already present in the dungeon so they do
 * Hide inside of a {{ site.data.dungeon.av.vault_rune }} during {{ site.data.dungeon.av.absolute_zero }}.
 * You should already be spreaded for {{ site.data.dungeon.av.icy_devastator }}, just use {{ site.data.talent.as }} if you are targeted.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.av.umbrelskul }}
 
@@ -1021,7 +1021,7 @@ The mobs before the last boss were all already present in the dungeon so they do
 * {{ site.data.talent.purge }} is very useful on the second boss, be sure to talent it if your group doesn't have one.
 * {{ site.data.talent.stoneskin_totem }} can be used in higher key for {{ site.data.dungeon.no.teera }}'s {{ site.data.dungeon.no.quick_shot }} and {{ site.data.dungeon.no.balakar_khan }}'s {{ site.data.dungeon.no.iron_spear }}.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.no.granyth }} trash
 **{{ site.data.dungeon.no.nokhud_longbow }}**
@@ -1039,7 +1039,7 @@ The mobs before the last boss were all already present in the dungeon so they do
 * Use {{ site.data.spell.wind_shear }} to interrupt {{ site.data.dungeon.no.disruptive_shout }}, stop casting if the cast is going through or you will be spell locked.
 * Stay farther than 8 yards away to ignore {{ site.data.dungeon.no.war_stomp }}.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.no.granyth }}
 * Have {{ site.data.spell.fs }} on all targets at all time.
@@ -1050,7 +1050,7 @@ The mobs before the last boss were all already present in the dungeon so they do
 
 *Note:* Using {{ site.data.dungeon.no.dragonkiller_lance }} early will prevent the second {{ site.data.dungeon.no.shards_of_stone }} and reduce party damage by a lot.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.no.the_raging_tempest }} trash
 
@@ -1072,7 +1072,7 @@ The mobs before the last boss were all already present in the dungeon so they do
 * {{ site.data.dungeon.no.totemic_overload }} will deal party-wide damage and a few {{ site.data.dungeon.no.uncontrollable_energy }} will spawn. Step on the lightning orbs to get a 5% damage increase stacking.
 * Use {{ site.data.spell.wind_shear }} to interrupt {{ site.data.dungeon.no.stormbolt }} if you are not kicking {{ site.data.dungeon.no.tempest }}.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.no.the_raging_tempest }}
 * Use {{ site.data.talent.purge }} to dispel {{ site.data.dungeon.no.energy_surge }}.
@@ -1082,7 +1082,7 @@ The mobs before the last boss were all already present in the dungeon so they do
 * Use {{ site.data.talent.as }} and {{ site.data.talent.ag }} to survive {{ site.data.dungeon.no.electrical_storm }}.
 * Don't go under the boss or {{ site.data.dungeon.no.the_raging_tempest_aoe }} will kill you.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.no.teera }} and {{ site.data.dungeon.no.maruuk }} trash
 
@@ -1107,7 +1107,7 @@ The mobs before the last boss were all already present in the dungeon so they do
 * Use {{ site.data.spell.wind_shear }} to interrupt {{ site.data.dungeon.no.death_bolt_volley }}. Assign a player to them if you have to.
 * Pick up your sould when targeted by {{ site.data.dungeon.no.shatter_soul }}. Use {{ site.data.talent.swg }} to keep uptime while doing it.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.no.teera }} and {{ site.data.dungeon.no.maruuk }}
 * Have {{ site.data.spell.fs }} up on both bosses at all times.
@@ -1117,7 +1117,7 @@ The mobs before the last boss were all already present in the dungeon so they do
 * Get ready to instantly use {{ site.data.spell.wind_shear }} to interrupt {{ site.data.dungeon.no.guardian_wind }} right after {{ site.data.dungeon.no.repel }}.
 * Dodge the brown swirlies during {{ site.data.dungeon.no.earthsplitter }}. Use {{ site.data.talent.swg }} to keep uptime while dodging.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.no.balakar_khan }} trash
 
@@ -1130,7 +1130,7 @@ A common route skip most of the trash in Nokhudon Hold, as they are very innefic
 * Dodge {{ site.data.dungeon.no.vehement_charge }}.
 * Don't be on the tank, {{ site.data.dungeon.no.broad_stomp }} is a frontal on him.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png"/></p>
+<hr>
 
 ### {{ site.data.dungeon.no.balakar_khan }}
 ### Phase 1
@@ -1159,7 +1159,7 @@ A common route skip most of the trash in Nokhudon Hold, as they are very innefic
 
 <br>
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png" width="130%"/></p>
+<hr>
 
 # Useful WeakAuras
 
@@ -1169,7 +1169,7 @@ A common route skip most of the trash in Nokhudon Hold, as they are very innefic
 * [Mythic+ Auto Marker](https://wago.io/1ctv3b91K) by Megawatt
 * [Mythic+ Timer](https://wago.io/M+Timer) by Reloe
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png" width="130%"/></p>
+<hr>
 
 # Additional Resources
 

--- a/guide/raids/SotFO.md
+++ b/guide/raids/SotFO.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: "Sepulcher of the First Ones Guide"
-date: 02/05/2022
+last_update: 02/05/2022
 game_version: 9.2 Shadowlands
 author: Eokira
 toc: false
@@ -54,8 +54,8 @@ The tips and recommendations listed here are based on educated opinions from PTR
 <div id="vigilant_guardian-collapse" class="collapse" aria-labelledby="vigilant_guardian" data-parent="#accordion">
 <div class="card-body" markdown="1">
 
-**Boss Fight Profile:** Single-Target with Cleave/AoE 
-          
+**Boss Fight Profile:** Single-Target with Cleave/AoE
+
 **Talents without {{ site.data.item.t28_4 }}:**
 
 * **15:** {{ site.data.talent.echo_of_the_elements }}
@@ -63,51 +63,51 @@ The tips and recommendations listed here are based on educated opinions from PTR
 * **30:** {{ site.data.talent.spirit_wolf }} or {{ site.data.talent.earth_shield }}
 * **35:** {{ site.data.talent.master_of_the_elements }}
 * **40:** {{ site.data.talent.natures_guardian }} or {{ site.data.talent.wind_rush_totem }} or {{ site.data.talent.ancestral_guidance }}
-* **45:** {{ site.data.talent.icefury }} 
+* **45:** {{ site.data.talent.icefury }}
 * **50:** {{ site.data.talent.stormkeeper }}
-       
+
 **Talents with {{ site.data.item.t28_4 }}:**
-       
+
 * **15:** {{ site.data.talent.echo }}       
-* **25:** {{ site.data.talent.eb }} or {{ site.data.talent.afs }} 
+* **25:** {{ site.data.talent.eb }} or {{ site.data.talent.afs }}
 * **30:** {{ site.data.talent.spirit_wolf }} or {{ site.data.talent.earth_shield }}
 * **35:** {{ site.data.talent.mote }} or {{ site.data.talent.se }}
 * **40:** {{ site.data.talent.natures_guardian }} or {{ site.data.talent.wrt }} or {{ site.data.talent.ancestral_guidance }}
 * **45:** {{ site.data.talent.pe }}
 * **50:** {{ site.data.talent.sk }}     
 
-**Recommended Covenant:** 
-       
+**Recommended Covenant:**
+
 * Night Fae with Dreamweaver or Korayn to capitalise on {{site.data.soulbinds.first_strike}}
-       
+
 **Recommended Legendaries:**
-       
+
 * {{ site.data.legendary.eogs }}  
 * {{ site.data.legendary.wlr }} If your group is able to kill Adds sufficiently fast in Normal or Heroic difficulty, you may find more value focussing on Single Target.
-       
+
 **Damage**
-       
+
 * Maintain {{ site.data.spell.flame_shock }} on multiple targets
 * Use {{ site.data.talent.stormkeeper }} when [Volatile Materium](https://ptr.wowhead.com/npc=181859/volatile-materium) are spawning, consider having a {{ site.data.legendary.eogs }} buff active!
 * Use {{ site.data.spell.spiritwalkers_grace }} to help reposition before [Exposed Core!](https://ptr.wowhead.com/spell=360412/exposed-core)
 
 **Defensives:**
 
-* Use cooldowns as necessary throughout the fight, ensuring at least {{ site.data.spell.astral_shift }} is available for [Core Overload](https://ptr.wowhead.com/spell=364962/core-overload) once the boss reaches 15%. 
-* If required, consider using {{ site.data.talent.ee }} with {{ site.data.spell.harden_skin }}. This may feel worse with an active 4-piece bonus but **dying is worse**. 
+* Use cooldowns as necessary throughout the fight, ensuring at least {{ site.data.spell.astral_shift }} is available for [Core Overload](https://ptr.wowhead.com/spell=364962/core-overload) once the boss reaches 15%.
+* If required, consider using {{ site.data.talent.ee }} with {{ site.data.spell.harden_skin }}. This may feel worse with an active 4-piece bonus but **dying is worse**.
 * Depending on your group composition and positioning your group may not need {{ site.data.talent.wrt }}, in which case take {{ site.data.talent.natures_guardian }}.
-       
+
 **Utilities:**
-       
+
 * Using {{ site.data.spell.wind_shear }} to interrupt [Point Defense Drone](https://ptr.wowhead.com/npc=181856/point-defense-drone)
 * Using {{ site.data.talent.thunderstorm }} to help position Adds when necessary
 * If talented, use {{ site.data.talent.wrt }} to help your raid reposition before [Exposed Core](https://ptr.wowhead.com/spell=360412/exposed-core)
 * If talented, use {{ site.data.talent.ancestral_guidance }} to help with incoming damage during Add spawns
-       
+
 **PTR PoVs:**
-          
+
 * Sheffy: [Heroic](https://www.twitch.tv/videos/1236486843)
-         
+
 </div>
 </div>
 </div>
@@ -117,10 +117,10 @@ The tips and recommendations listed here are based on educated opinions from PTR
 <div data-toggle="collapse" data-target="#skolex-collapse" aria-expanded="true" aria-controls="skolex-collapse" class="raid-header sepulcher_of_the_first_ones2"><h2>Skolex, the Insatiable Ravener</h2></div>
 </div>
 <div id="skolex-collapse" class="collapse" aria-labelledby="skolex" data-parent="#accordion">
-<div class="card-body" markdown="1"> 
- 
+<div class="card-body" markdown="1">
+
 **Boss Fight Profile:** Single-Target
-          
+
 **Talents without {{ site.data.item.t28_4 }}:**
 
 * **15:** {{ site.data.talent.echo_of_the_elements }}
@@ -128,11 +128,11 @@ The tips and recommendations listed here are based on educated opinions from PTR
 * **30:** {{ site.data.talent.spirit_wolf }} or {{ site.data.talent.earth_shield }}
 * **35:** {{ site.data.talent.master_of_the_elements }}
 * **40:** {{ site.data.talent.natures_guardian }} or {{ site.data.talent.wind_rush_totem }}
-* **45:** {{ site.data.talent.icefury }} 
+* **45:** {{ site.data.talent.icefury }}
 * **50:** {{ site.data.talent.stormkeeper }}
-       
+
 **Talents with {{ site.data.item.t28_4 }}:**
-       
+
 * **15:** {{ site.data.talent.echo }}       
 * **25:** {{ site.data.talent.eb }}
 * **30:** {{ site.data.talent.spirit_wolf }} or {{ site.data.talent.earth_shield }}
@@ -140,47 +140,47 @@ The tips and recommendations listed here are based on educated opinions from PTR
 * **40:** {{ site.data.talent.natures_guardian }} or {{ site.data.talent.wrt }}
 * **45:** {{ site.data.talent.pe }}
 * **50:** {{ site.data.talent.sk }} or {{ site.data.talent.asc }}
-       
-**Recommended Covenant:** 
-       
-* Night Fae with Dreamweaver 
+
+**Recommended Covenant:**
+
+* Night Fae with Dreamweaver
 * Necrolord with Plague-Deviser Marileth
-       
+
 **Recommended Legendaries:**
 
 * {{ site.data.legendary.wlr }}
-       
+
 **Damage**
-       
+
 * Use {{ site.data.spell.spiritwalkers_grace }} to maintain uptime while avoiding [Retch](https://ptr.wowhead.com/spell=360448/retch) or when repositioning for [Ravening Burrow](https://ptr.wowhead.com/spell=359770/ravening-burrow)
 * You can continue using instant-cast abilities whilst airborne from [Ravening Burrow!](https://ptr.wowhead.com/spell=359770/ravening-burrow)
-       
+
 **Defensives:**
-       
+
 * Use {{ site.data.spell.astral_shift }} and healing consumables as required to deal with additional stacks of [Ephemera Dust](https://ptr.wowhead.com/spell=359778/ephemera-dust).
 * Consider using {{ site.data.talent.ee }} as an additional defensive with {{ site.data.talent.icefury }} talented, or as required if using {{ site.data.talent.pe }} talented when 4-piece is active.
 
 **Utilities:**
-       
+
 * If talented, use {{ site.data.talent.wrt }} to help your raid avoid [Retch](https://ptr.wowhead.com/spell=360448/retch)
-       
+
 **PTR PoVs:**
 
 * Sheffy: [Heroic](https://www.twitch.tv/videos/1223228452) \| [Mythic](https://www.twitch.tv/videos/1255340962)
-  
+
 </div>
 </div>
 </div>
-    
+
 <div class="card">
 <div class="card-header" id="artificer_xymox">
 <div data-toggle="collapse" data-target="#artificer_xymox-collapse" aria-expanded="true" aria-controls="artificer_xymox-collapse" class="raid-header sepulcher_of_the_first_ones3"><h2>Artificer Xy'mox</h2></div>
 </div>
 <div id="artificer_xymox-collapse" class="collapse" aria-labelledby="artificer_xymox" data-parent="#accordion">
 <div class="card-body" markdown="1">
- 
-**Boss Fight Profile:** Single-Target with AoE 
-          
+
+**Boss Fight Profile:** Single-Target with AoE
+
 **Talents without {{ site.data.item.t28_4 }}:**
 
 * **15:** {{ site.data.talent.echo_of_the_elements }}
@@ -188,11 +188,11 @@ The tips and recommendations listed here are based on educated opinions from PTR
 * **30:** {{ site.data.talent.spirit_wolf }}
 * **35:** {{ site.data.talent.master_of_the_elements }} (or {{ site.data.talent.se }} for Add damage )
 * **40:** {{ site.data.talent.natures_guardian }} or {{ site.data.talent.wind_rush_totem }}
-* **45:** {{ site.data.talent.icefury }} 
+* **45:** {{ site.data.talent.icefury }}
 * **50:** {{ site.data.talent.stormkeeper }}
-       
+
 **Talents with {{ site.data.item.t28_4 }}:**
-       
+
 * **15:** {{ site.data.talent.echo }}       
 * **25:** {{ site.data.talent.eb }} ( or {{ site.data.talent.afs }} for Add damage )
 * **30:** {{ site.data.talent.spirit_wolf }}
@@ -200,55 +200,55 @@ The tips and recommendations listed here are based on educated opinions from PTR
 * **40:** {{ site.data.talent.natures_guardian }} or {{ site.data.talent.wrt }}
 * **45:** {{ site.data.talent.pe }} (or {{ site.data.talent.se }} for Add damage )
 * **50:** {{ site.data.talent.sk }}     
- 
+
 **Recommended Covenant:**   
-       
+
 * Night Fae with Dreamweaver or Korayn to capitalise on {{site.data.soulbinds.first_strike}}
-       
+
 **Recommended Legendaries:**
- 
+
 * {{ site.data.legendary.eogs }}
 * {{ site.data.legendary.wlr }}
-       
+
 **Damage**
-       
-* Focus down [Xy Acolytes](https://ptr.wowhead.com/npc=184140/xy-acolyte) as fast as possible to prevent [Hyperlight Ascension](https://ptr.wowhead.com/spell=364040/hyperlight-ascension) 
+
+* Focus down [Xy Acolytes](https://ptr.wowhead.com/npc=184140/xy-acolyte) as fast as possible to prevent [Hyperlight Ascension](https://ptr.wowhead.com/spell=364040/hyperlight-ascension)
 * Use {{ site.data.talent.sk }} when [Xy Acolytes](https://ptr.wowhead.com/npc=184140/xy-acolyte) and [Xy Spellslingers](https://ptr.wowhead.com/npc=183707/xy-spellslinger) are spawning, consider having a {{ site.data.legendary.eogs }} buff active!
 * Use {{ site.data.spell.spiritwalkers_grace }} to maintain uptime whilst dealing with [Genesis Rings!](https://ptr.wowhead.com/spell=363413/genesis-rings)
-       
+
 **Defensives:**
-       
+
 * Use {{ site.data.spell.astral_shift }} as needed when [Gylph of Relocation](https://ptr.wowhead.com/spell=362801/glyph-of-relocation) is about to explode
 * Consider using {{ site.data.talent.ee }} as necessary for [Vital Accretion](https://ptr.wowhead.com/spell=337981/vital-accretion) or {{ site.data.spell.harden_skin }}
-       
+
 **Utilities:**
-       
+
 * Use {{ site.data.spell.wind_shear }} to interrupt [Debilitating Ray](https://ptr.wowhead.com/spell=364030/debilitating-ray) from [Xy Spellslingers](https://ptr.wowhead.com/npc=183707/xy-spellslinger)
 * Use {{ site.data.talent.thunderstorm }} to position [Xy Acolytes](https://ptr.wowhead.com/npc=184140/xy-acolyte) and [Xy Spellslingers](https://ptr.wowhead.com/npc=183707/xy-spellslinger) if necessary
 * Use {{ site.data.talent.capacitor_totem }} to stun [Xy Acolytes](https://ptr.wowhead.com/npc=184140/xy-acolyte) and [Xy Spellslingers](https://ptr.wowhead.com/npc=183707/xy-spellslinger)
 * If talented, use {{ site.data.talent.wrt }} to help your raid avoid [Genesis Rings](https://ptr.wowhead.com/spell=363413/genesis-rings)
-       
+
 **Added Notes:**
-       
+
 * Position yourself accordingly whenever [Glyph of Relocation](https://ptr.wowhead.com/spell=362801/glyph-of-relocation) is about to expire, so that a [Dimensional Tear](https://ptr.wowhead.com/spell=362721/dimensional-tear) is between you and the exploding tank. This allows you to minimize the distance moved.        
-       
+
 **PTR PoVs:**
 
 * Sheffy: [Heroic](https://www.twitch.tv/videos/1229013142)
-  
+
 </div>
 </div>
 </div>
-    
+
 <div class="card">
 <div class="card-header" id="dausegne">
 <div data-toggle="collapse" data-target="#dausegne-collapse" aria-expanded="true" aria-controls="dausegne-collapse" class="raid-header sepulcher_of_the_first_ones4"><h2>Dausegne, the Fallen Oracle</h2></div>
 </div>
 <div id="dausegne-collapse" class="collapse" aria-labelledby="dausegne" data-parent="#accordion">
 <div class="card-body" markdown="1">    
-  
-**Boss Fight Profile:** Single-Target, with limited Cleave/Funnel 
-          
+
+**Boss Fight Profile:** Single-Target, with limited Cleave/Funnel
+
 **Talents without {{ site.data.item.t28_4 }}:**
 
 * **15:** {{ site.data.talent.echo_of_the_elements }}
@@ -256,11 +256,11 @@ The tips and recommendations listed here are based on educated opinions from PTR
 * **30:** {{ site.data.talent.spirit_wolf }}
 * **35:** {{ site.data.talent.master_of_the_elements }}
 * **40:** {{ site.data.talent.natures_guardian }} or {{ site.data.talent.wind_rush_totem }}
-* **45:** {{ site.data.talent.icefury }} 
+* **45:** {{ site.data.talent.icefury }}
 * **50:** {{ site.data.talent.stormkeeper }}
-       
+
 **Talents with {{ site.data.item.t28_4 }}:**
-       
+
 * **15:** {{ site.data.talent.echo }}       
 * **25:** {{ site.data.talent.eb }}
 * **30:** {{ site.data.talent.spirit_wolf }}
@@ -268,53 +268,53 @@ The tips and recommendations listed here are based on educated opinions from PTR
 * **40:** {{ site.data.talent.natures_guardian }} or {{ site.data.talent.wrt }}
 * **45:** {{ site.data.talent.pe }}
 * **50:** {{ site.data.talent.sk }} or {{ site.data.talent.asc }}   
- 
+
 **Recommended Covenant:**   
-       
+
 * Night Fae with Dreamweaver
-       
+
 **Recommended Legendaries:**
-       
+
 * {{ site.data.legendary.wlr }}       
-  
+
 **Damage**
-       
+
 * [Domination Cores](https://ptr.wowhead.com/npc=181244/domination-core) can be played in more than one way from an Elemental perspective:
-       - Maintain {{ site.data.spell.flame_shock }} on both Dausegne and [Domination Core](https://ptr.wowhead.com/npc=181244/domination-core), focus single-target damage into [Domination Core](https://ptr.wowhead.com/npc=181244/domination-core) 
+       - Maintain {{ site.data.spell.flame_shock }} on both Dausegne and [Domination Core](https://ptr.wowhead.com/npc=181244/domination-core), focus single-target damage into [Domination Core](https://ptr.wowhead.com/npc=181244/domination-core)
        - Maintain {{ site.data.spell.flame_shock }} on both Dausegne and [Domination Core](https://ptr.wowhead.com/npc=181244/domination-core), focus single-target damage into Dausegne
        - Maintain {{ site.data.spell.flame_shock }} on both Dausegne and [Domination Core](https://ptr.wowhead.com/npc=181244/domination-core), use {{ site.data.spell.eq }} instead of {{ site.data.spell.es }} and focus either [Domination Core](https://ptr.wowhead.com/npc=181244/domination-core) or Dausegne
        - Recommendation? Be sensible. For progression purposes it is important that [Domination Cores](https://ptr.wowhead.com/npc=181244/domination-core) die quickly because of [Encroaching Dominion](https://ptr.wowhead.com/spell=361214/encroaching-dominion) pools they spawn every 6 seconds whilst still alive, every group is different so your needs may vary but the priority should be to do what is necessary to kill the [Domination Cores](https://ptr.wowhead.com/npc=181244/domination-core) quickly and efficiently.  
 * Use {{ site.data.spell.spiritwalkers_grace }} to maintain uptime whilst dealing with [Disintegration Halo](https://ptr.wowhead.com/spell=365373/disintegration-halo)
 * Pool resources when Dausegne is about to cast [Siphon Reservoir!](https://ptr.wowhead.com/spell=361643/siphon-reservoir)       
-       
+
 **Defensives:**
-       
+
 * Use {{ site.data.spell.astral_shift }} as needed when [Staggering Barrage](https://ptr.wowhead.com/spell=360959/staggering-barrage), [Disintegration Halo](https://ptr.wowhead.com/spell=365373/disintegration-halo) or [Inevitable Dominion](https://ptr.wowhead.com/spell=361722/inevitable-dominion) happen
 * Consider using {{ site.data.talent.ee }} as necessary for [Vital Accretion](https://ptr.wowhead.com/spell=337981/vital-accretion) or {{ site.data.spell.harden_skin }}
 * {{ site.data.spell.soulshape }} is useful for dealing with [Disintegration Halo](https://ptr.wowhead.com/spell=365373/disintegration-halo) overlaps when playing as Night Fae
-       
+
 **Utilities:**
-       
+
 * Use {{ site.data.spell.wind_shear }} to interrupt [Domination Bolt](https://ptr.wowhead.com/spell=363607/domination-bolt) from [Domination Core](https://ptr.wowhead.com/npc=181244/domination-core)  
 * If talented, use {{ site.data.talent.wrt }} to help your raid deal with [Disintegration Halo](https://ptr.wowhead.com/spell=365373/disintegration-halo) overlaps.  
-       
+
 **PTR PoVs:**
 
 * Sheffy: [Heroic](https://www.twitch.tv/videos/1223223675) \| [Mythic](https://www.twitch.tv/videos/1255367010)
-  
+
 </div>
 </div>
 </div>
-    
+
 <div class="card">
 <div class="card-header" id="prototype_pantheon">
 <div data-toggle="collapse" data-target="#prototype_pantheon-collapse" aria-expanded="true" aria-controls="prototype_pantheon-collapse" class="raid-header sepulcher_of_the_first_ones5"><h2>Prototype Pantheon</h2></div>
 </div>
 <div id="prototype_pantheon-collapse" class="collapse" aria-labelledby="prototype_pantheon" data-parent="#accordion">
 <div class="card-body" markdown="1">    
-  
+
 **Boss Fight Profile:** Cleave with spread priority Add spawn
-          
+
 **Talents without {{ site.data.item.t28_4 }}:**
 
 * **15:** {{ site.data.talent.echo_of_the_elements }}
@@ -324,9 +324,9 @@ The tips and recommendations listed here are based on educated opinions from PTR
 * **40:** {{ site.data.talent.natures_guardian }} or {{ site.data.talent.wind_rush_totem }}
 * **45:** {{ site.data.talent.icefury }} or {{ site.data.talent.pe }}
 * **50:** {{ site.data.talent.stormkeeper }}
-       
+
 **Talents with {{ site.data.item.t28_4 }}:**
-       
+
 * **15:** {{ site.data.talent.eote }}
 * **25:** {{ site.data.talent.eb }} or {{ site.data.talent.afs }}
 * **30:** {{ site.data.talent.spirit_wolf }} or {{ site.data.talent.earth_shield }}
@@ -334,49 +334,49 @@ The tips and recommendations listed here are based on educated opinions from PTR
 * **40:** {{ site.data.talent.natures_guardian }} or {{ site.data.talent.wrt }}
 * **45:** {{ site.data.talent.pe }}
 * **50:** {{ site.data.talent.sk }} or {{ site.data.talent.asc }}
-       
+
 **Recommended Covenant:**   
-       
+
 * Necrolord with Plague Deviser Marileth, {{ site.data.soulbinds.preemptive_strike }} is very effective for focusing Necrotic Ritualists
 * Night Fae with Dreamweaver
-       
+
 **Recommended Legendaries:**
-       
+
 * {{ site.data.legendary.eogs }}
 * {{ site.data.legendary.dre }}
-  
+
 **Damage**
-       
-* Focusing [Necrotic Rituatlists](https://ptr.wowhead.com/spell=360295/necrotic-ritual#used-by-npc) is very important, maintain {{ site.data.spell.flame_shock }} on as many targets whilst focusing one [Necrotic Ritualist](https://ptr.wowhead.com/spell=360295/necrotic-ritual#used-by-npc) down (consider positioning for this purpose) 
+
+* Focusing [Necrotic Rituatlists](https://ptr.wowhead.com/spell=360295/necrotic-ritual#used-by-npc) is very important, maintain {{ site.data.spell.flame_shock }} on as many targets whilst focusing one [Necrotic Ritualist](https://ptr.wowhead.com/spell=360295/necrotic-ritual#used-by-npc) down (consider positioning for this purpose)
 * Use {{ site.data.spell.spiritwalkers_grace }} to maintain uptime whilst dealing with [Windswept Wings](https://ptr.wowhead.com/spell=365041/windswept-wings) and [Hand of Destruction](https://ptr.wowhead.com/spell=361788/hand-of-destruction)
-       
+
 **Defensives:**
-       
+
 * Use {{ site.data.spell.astral_shift }} (and {{ site.data.spell.fleshcraft }} if Necrolord) as needed for [Windswept Wings](https://ptr.wowhead.com/spell=365041/windswept-wings)
-* Consider using {{ site.data.talent.ee }} as necessary for [Vital Accretion](https://ptr.wowhead.com/spell=337981/vital-accretion) or {{ site.data.spell.harden_skin }} 
+* Consider using {{ site.data.talent.ee }} as necessary for [Vital Accretion](https://ptr.wowhead.com/spell=337981/vital-accretion) or {{ site.data.spell.harden_skin }}
 
 **Utilities:**
-       
+
 * Use {{ site.data.spell.wind_shear }} to interrupt [Gloom Bolt](https://ptr.wowhead.com/spell=360259/gloom-bolt) from [Prototype of War](https://ptr.wowhead.com/npc=181549/prototype-of-war) and [Anima Bolt](https://ptr.wowhead.com/spell=362383/anima-bolt) from [Protoype of Renewal](https://ptr.wowhead.com/npc=181546/prototype-of-renewal)  
 * If talented, use {{ site.data.talent.wrt }} to help your raid deal with [Windswept Wings](https://ptr.wowhead.com/spell=365041/windswept-wings) and [Hand of Destruction](https://ptr.wowhead.com/spell=361788/hand-of-destruction)
-       
+
 **PTR PoVs:**
 
 * Sheffy: [Heroic](https://www.twitch.tv/videos/1235533062)
-  
+
 </div>
 </div>
 </div>
-    
+
 <div class="card">
 <div class="card-header" id="lihuvim">
 <div data-toggle="collapse" data-target="#lihuvim-collapse" aria-expanded="true" aria-controls="lihuvim-collapse" class="raid-header sepulcher_of_the_first_ones6"><h2>Lihuvim, Principal Architech</h2></div>
 </div>
 <div id="lihuvim-collapse" class="collapse" aria-labelledby="lihuvim" data-parent="#accordion">
 <div class="card-body" markdown="1">    
-  
+
 **Boss Fight Profile:** Single-Target with Cleave / AoE
-          
+
 **Talents without {{ site.data.item.t28_4 }}:**
 
 * **15:** {{ site.data.talent.echo_of_the_elements }}
@@ -384,61 +384,61 @@ The tips and recommendations listed here are based on educated opinions from PTR
 * **30:** {{ site.data.talent.spirit_wolf }}
 * **35:** {{ site.data.talent.master_of_the_elements }}
 * **40:** {{ site.data.talent.natures_guardian }} or {{ site.data.talent.wind_rush_totem }}
-* **45:** {{ site.data.talent.icefury }} 
+* **45:** {{ site.data.talent.icefury }}
 * **50:** {{ site.data.talent.stormkeeper }}
-       
+
 **Talents with {{ site.data.item.t28_4 }}:**
-       
+
 * **15:** {{ site.data.talent.eote }}
 * **25:** {{ site.data.talent.eb }} ( or {{ site.data.talent.afs }} for Add damage }}
 * **30:** {{ site.data.talent.spirit_wolf }}
-* **35:** {{ site.data.talent.mote }} ( or {{ site.data.talent.se }} for Add damage }} 
+* **35:** {{ site.data.talent.mote }} ( or {{ site.data.talent.se }} for Add damage }}
 * **40:** {{ site.data.talent.natures_guardian }} or {{ site.data.talent.wrt }}
 * **45:** {{ site.data.talent.pe }}
 * **50:** {{ site.data.talent.sk }}     
- 
+
 **Recommended Covenant:**   
-       
+
 * Night Fae with Korayn for {{site.data.soulbinds.first_strike}}
 * Necrolord with Plague-Deviser Marileth
-       
+
 **Recommended Legendaries:**
 
 * {{ site.data.legendary.wlr }}
-* {{ site.data.legendary.eogs }} 
-       
+* {{ site.data.legendary.eogs }}
+
 **Damage**
-       
+
 * Pool resources when Lihuvim is close to 100 energy to prepare for [Synthesize](https://ptr.wowhead.com/spell=363130/synthesize)
 * Focusing down [Degeneration Automa](https://ptr.wowhead.com/npc=182053/degeneration-automa), [Acquisitions Automa](https://ptr.wowhead.com/npc=184737/acquisitions-automa), [Guardian Automa](https://ptr.wowhead.com/npc=184738/guardian-automa), [Defense Matrix Automa](https://ptr.wowhead.com/npc=184126/defense-matrix-automa) is the highest priority when they are active
 * Use {{ site.data.spell.spiritwalkers_grace }} to maintain uptime whilst dealing with [Manifest Mote](https://ptr.wowhead.com/spell=362624/manifest-mote) and [Deconstruction Blast](https://ptr.wowhead.com/spell=363681/deconstructing-blast)
-       
+
 **Defensives:**
-       
+
 * Use {{ site.data.spell.astral_shift }} as needed for [Cosmic Shift](https://ptr.wowhead.com/spell=363088/cosmic-shift) or [Deconstruction Blast](https://ptr.wowhead.com/spell=363681/deconstructing-blast)
-* Consider using {{ site.data.talent.ee }} as necessary for [Vital Accretion](https://ptr.wowhead.com/spell=337981/vital-accretion) or {{ site.data.spell.harden_skin }} 
-       
+* Consider using {{ site.data.talent.ee }} as necessary for [Vital Accretion](https://ptr.wowhead.com/spell=337981/vital-accretion) or {{ site.data.spell.harden_skin }}
+
 **Utilities:**
 
 * If talented, use {{ site.data.talent.wrt }} to help your raid reposition quickly for [Synthesize](https://ptr.wowhead.com/spell=363130/synthesize)
-       
+
 **PTR PoVs:**
-  
+
 * Sheffy: [Heroic](https://www.twitch.tv/videos/1229048431)
-  
+
 </div>
 </div>
 </div>
-    
+
 <div class="card">
 <div class="card-header" id="halondrus">
 <div data-toggle="collapse" data-target="#halondrus-collapse" aria-expanded="true" aria-controls="halondrus-collapse" class="raid-header sepulcher_of_the_first_ones7"><h2>Halondrus the Reclaimer</h2></div>
 </div>
 <div id="halondrus-collapse" class="collapse" aria-labelledby="halondrus" data-parent="#accordion">
 <div class="card-body" markdown="1">    
-  
-**Boss Fight Profile:** Single-Target 
-          
+
+**Boss Fight Profile:** Single-Target
+
 **Talents without {{ site.data.item.t28_4 }}:**
 
 * **15:** {{ site.data.talent.echo_of_the_elements }}
@@ -446,60 +446,60 @@ The tips and recommendations listed here are based on educated opinions from PTR
 * **30:** {{ site.data.talent.spirit_wolf }}
 * **35:** {{ site.data.talent.master_of_the_elements }}
 * **40:** {{ site.data.talent.natures_guardian }} or {{ site.data.talent.wind_rush_totem }}
-* **45:** {{ site.data.talent.icefury }} 
+* **45:** {{ site.data.talent.icefury }}
 * **50:** {{ site.data.talent.stormkeeper }}
-       
+
 **Talents with {{ site.data.item.t28_4 }}:**
-       
-* **15:** {{ site.data.talent.echo }} 
+
+* **15:** {{ site.data.talent.echo }}
 * **25:** {{ site.data.talent.eb }}
-* **30:** {{ site.data.talent.spirit_wolf }} or {{ site.data.talent.earth_shield }} 
+* **30:** {{ site.data.talent.spirit_wolf }} or {{ site.data.talent.earth_shield }}
 * **35:** {{ site.data.talent.mote }}  
 * **40:** {{ site.data.talent.natures_guardian }} or {{ site.data.talent.wrt }}
 * **45:** {{ site.data.talent.pe }}
 * **50:** {{ site.data.talent.sk }} or {{ site.data.talent.asc }}
-       
+
 **Recommended Covenant:**   
-       
+
 * Night Fae with Dreamweaver (consider Niya if you would otherwise have poor {{ site.data.soulbinds.field_of_blossom }} uptime and/or delay {{ site.data.spell.fae_transfusion }} in order to facilitate uptime)
 * Necrolord with Plague Deviser Marileth (less reliant on static positioning, additional defensive never hurts!)
-       
+
 **Recommended Legendaries:**
 
-* {{ site.data.legendary.wlr }} 
-       
+* {{ site.data.legendary.wlr }}
+
 **Damage**
-       
+
 * Make use of Elemental's frequent instant cast abilities to deal with movement caused by [Earthbreaker Missiles](https://www.wowhead.com/spell=361676/earthbreaker-missiles) and [Aftershock](https://www.wowhead.com/spell=362025/aftershock)
 * {{ site.data.spell.spiritwalkers_grace }} is important to use during Intermissions, and if time allows, during Phase 3.
-       
+
 **Defensives:**
-       
+
 * Using {{ site.data.spell.astral_shift }} during [Reclaim](https://www.wowhead.com/spell=360115/reclaim), and during Phase 3.
 * {{ site.data.talent.earth_shield }} does a lot of healing on this fight, and is no issue to recast due to movement required in all phases.
-       
+
 **Utilities:**
-       
+
 * {{ site.data.talent.wrt }} is exceptionally useful when placed going into Intermission phases  
-       
+
 **PTR PoVs:**
-       
+
 * Remember: this footage is from before rework!  
 * Sheffy: [Heroic](https://www.twitch.tv/videos/1235530886)
-  
+
 </div>
 </div>
 </div>  
-    
+
 <div class="card">
 <div class="card-header" id="anduin_wrynn">
 <div data-toggle="collapse" data-target="#anduin_wrynn-collapse" aria-expanded="true" aria-controls="anduin_wrynn-collapse" class="raid-header sepulcher_of_the_first_ones8"><h2>Anduin Wrynn</h2></div>
 </div>
 <div id="anduin_wrynn-collapse" class="collapse" aria-labelledby="anduin_wrynn" data-parent="#accordion">
 <div class="card-body" markdown="1">   
-  
+
 **Boss Fight Profile:** Single-Target with Cleave / AoE
-          
+
 **Talents without {{ site.data.item.t28_4 }}:**
 
 * **15:** {{ site.data.talent.echo_of_the_elements }}
@@ -509,9 +509,9 @@ The tips and recommendations listed here are based on educated opinions from PTR
 * **40:** {{ site.data.talent.wind_rush_totem }} or {{ site.data.talent.ancestral_guidance }}
 * **45:** {{ site.data.talent.icefury }} or {{ site.data.talent.pe }}
 * **50:** {{ site.data.talent.stormkeeper }}
-       
+
 **Talents with {{ site.data.item.t28_4 }}:**
-       
+
 * **15:** {{ site.data.talent.eote }}
 * **25:** {{ site.data.talent.eb }} (or {{ site.data.talent.afs }} for Add damage / you plan to use {{ site.data.talent.se }})
 * **30:** {{ site.data.talent.spirit_wolf }}
@@ -519,24 +519,24 @@ The tips and recommendations listed here are based on educated opinions from PTR
 * **40:** {{ site.data.talent.wrt }} or {{ site.data.talent.ancestral_guidance }}
 * **45:** {{ site.data.talent.pe }}
 * **50:** {{ site.data.talent.sk }}  
- 
+
 **Recommended Covenant:**   
-       
+
 * Night Fae with Korayn
-       
+
 **Recommended Legendaries:**
 
 * {{ site.data.legendary.eogs }}
-       
+
 **Damage**
-       
-* Use {{ site.data.spell.spiritwalkers_grace }} to maintain uptime whilst dealing with [Blasphemy](https://ptr.wowhead.com/spell=361989/blasphemy) 
+
+* Use {{ site.data.spell.spiritwalkers_grace }} to maintain uptime whilst dealing with [Blasphemy](https://ptr.wowhead.com/spell=361989/blasphemy)
 * Pool resources, including {{ site.data.talent.sk }}, for the Intermission phase       
-       
+
 **Defensives:**
-       
+
 * Use {{ site.data.spell.astral_shift }} as needed for [Befouled Barrier](https://ptr.wowhead.com/spell=365293/befouled-barrier) or [Hopebreaker](https://ptr.wowhead.com/spell=361815/hopebreaker)
-       
+
 **Utilities:**
 
 * Use {{ site.data.spell.wind_shear }} to interrupt [Psychic Terror](https://ptr.wowhead.com/spell=365008/psychic-terror) from [Grim Reflections](https://ptr.wowhead.com/spell=365120/grim-reflections)        
@@ -544,36 +544,36 @@ The tips and recommendations listed here are based on educated opinions from PTR
 * Use {{ site.data.spell.fae_transfusion }} to assist with breaking [Befouled Barrier](https://ptr.wowhead.com/spell=365293/befouled-barrier)
 * Use {{ site.data.talent.capacitor_totem }} to assist with controlling Adds       
 * If talented, use {{ site.data.talent.ancestral_guidance }} with {{ site.data.talent.sk }} for maximum effect        
-       
+
 **PTR PoVs:**
-  
+
 * Sheffy: [Heroic](https://www.twitch.tv/videos/1236484005)
-  
+
 </div>
 </div>
 </div>   
-    
+
 <div class="card">
 <div class="card-header" id="lords_of_dread">
 <div data-toggle="collapse" data-target="#lords_of_dread-collapse" aria-expanded="true" aria-controls="lords_of_dread-collapse" class="raid-header sepulcher_of_the_first_ones9"><h2>Lords of Dread</h2></div>
 </div>
 <div id="lords_of_dread-collapse" class="collapse" aria-labelledby="lords_of_dread" data-parent="#accordion">
 <div class="card-body" markdown="1">   
-  
+
 **Boss Fight Profile:** Two target Cleave with Single Add spawn
-          
+
 **Talents without {{ site.data.item.t28_4 }}:**
 
 * **15:** {{ site.data.talent.echo_of_the_elements }}
-* **25:** {{ site.data.talent.elemental_blast }} 
+* **25:** {{ site.data.talent.elemental_blast }}
 * **30:** {{ site.data.talent.spirit_wolf }}
 * **35:** {{ site.data.talent.se }} or {{ site.data.talent.master_of_the_elements }}
 * **40:** {{ site.data.talent.wind_rush_totem }} or {{ site.data.talent.natures_guardian }}
 * **45:** {{ site.data.talent.icefury }} or {{ site.data.talent.pe }}
 * **50:** {{ site.data.talent.stormkeeper }}
-       
+
 **Talents with {{ site.data.item.t28_4 }}:**
-       
+
 * **15:** {{ site.data.talent.eote }}
 * **25:** {{ site.data.talent.eb }} or {{ site.data.talent.afs }}
 * **30:** {{ site.data.talent.spirit_wolf }}
@@ -581,60 +581,60 @@ The tips and recommendations listed here are based on educated opinions from PTR
 * **40:** {{ site.data.talent.wrt }} or {{ site.data.talent.natures_guardian }}
 * **45:** {{ site.data.talent.pe }}
 * **50:** {{ site.data.talent.sk }} or {{ site.data.talent.asc }}
- 
+
 **Recommended Covenant:**   
-       
+
 * Necrolord with Plague-Deviser Marileth
 * Night Fae with Dreamweaver
-       
+
 **Recommended Legendaries:**
 
 * {{ site.data.legendary.dre }} despite the RNG nature of this Legendary effect it plays well into the low target counts offered by the fight so on average should provide the most value
 * {{ site.data.legendary.eogs }} You may consider this if you dislike the RNG nature of {{ site.data.legendary.dre }}
-       
+
 **Damage**
-       
+
 * Maintain {{ site.data.spell.fs }} on both bosses.
 * Prepare for [Unto Darkness](https://www.wowhead.com/spell=360319/unto-darkness) when Malganis is nearing 100 Energy by getting an {{ site.data.legendary.eogs }} buff active if it is equipped
 * All damage is now increased by [Unto Darkness](https://www.wowhead.com/spell=360319/unto-darkness) meaning no special rules apply to how you would use abilities in this phase, normal 2 target priority is used (3 targets when [Inchoate Shadow Add](https://www.wowhead.com/npc=183138/inchoate-shadow) is gripped in)
-       
+
 **Defensives:**
-       
+
 * Use {{ site.data.spell.astral_shift }} during [Unto Darkness](https://www.wowhead.com/spell=360319/unto-darkness), it should not be necessary to use defensives to deal with [Cloud of Carrion](https://www.wowhead.com/spell=360006/cloud-of-carrion) if stacks are spread appropriately
-       
+
 **Utilities:**
-       
+
 * {{ site.data.talent.tremor_totem }} can be used to remove [Bursting Dread Fears](https://www.wowhead.com/spell=360148/bursting-dread) in the event of a mistake. Be particularly mindful if your healers make this mistake, as it will typically be healers that dispel the fear from others! Can also be useful to clear [Unsettling Dreams](https://www.wowhead.com/spell=360241/unsettling-dreams)
 * {{ site.data.spell.wind_shear }} is excellent for the [Inchoate Shadow Add](https://www.wowhead.com/npc=183138/inchoate-shadow) but remember **do not interrupt the casts until the Add has reached 100% hp and their buff is removed**, doing so will cause more raid damage overall via  [Ravenous Hunger](https://www.wowhead.com/spell=361923/ravenous-hunger)
 * {{ site.data.talent.thunderstorm }} can be used to knock the [Inchoate Shadow Add](https://www.wowhead.com/npc=183138/inchoate-shadow) into the bosses to more efficiently cleave it down.
-  
+
 </div>
 </div>
 </div>
-    
+
 <div class="card">
 <div class="card-header" id="rygelon">
 <div data-toggle="collapse" data-target="#rygelon-collapse" aria-expanded="true" aria-controls="rygelon-collapse" class="raid-header sepulcher_of_the_first_ones10"><h2>Rygelon</h2></div>
 </div>
 <div id="rygelon-collapse" class="collapse" aria-labelledby="rygelon" data-parent="#accordion">
 <div class="card-body" markdown="1">  
-  
+
 **Boss Fight Profile:** Single Target with Priority Adds
-          
+
 **Talents:**
 
 **Talents without {{ site.data.item.t28_4 }}:**
 
 * **15:** {{ site.data.talent.echo_of_the_elements }}
-* **25:** {{ site.data.talent.elemental_blast }} 
+* **25:** {{ site.data.talent.elemental_blast }}
 * **30:** {{ site.data.talent.spirit_wolf }}
 * **35:** {{ site.data.talent.se }} or {{ site.data.talent.master_of_the_elements }}
 * **40:** {{ site.data.talent.wind_rush_totem }} or {{ site.data.talent.natures_guardian }}
 * **45:** {{ site.data.talent.icefury }} or {{ site.data.talent.pe }}
 * **50:** {{ site.data.talent.stormkeeper }}
-       
+
 **Talents with {{ site.data.item.t28_4 }}:**
-       
+
 * **15:** {{ site.data.talent.eote }}
 * **25:** {{ site.data.talent.eb }} or {{ site.data.talent.afs }}
 * **30:** {{ site.data.talent.spirit_wolf }}
@@ -642,59 +642,59 @@ The tips and recommendations listed here are based on educated opinions from PTR
 * **40:** {{ site.data.talent.wrt }} or {{ site.data.talent.natures_guardian }}
 * **45:** {{ site.data.talent.pe }}
 * **50:** {{ site.data.talent.sk }} or {{ site.data.talent.asc }}
- 
+
 **Recommended Covenant:**   
-       
+
 * Necrolord with Plague-Deviser Marileth
-* Night Fae with Dreamweaver or Korayn for {{ site.data.soulbinds.first_strike }} 
-       
+* Night Fae with Dreamweaver or Korayn for {{ site.data.soulbinds.first_strike }}
+
 **Recommended Legendaries:**
 
 * {{ site.data.legendary.wlr }}
 * {{ site.data.legendary.dre }}
-       
+
 **Damage**
-       
+
 * Swap to [Collapsing Quasar Orbs](https://www.wowhead.com/npc=182778/collapsing-quasar) and ensure they die before reaching the boss. Pooling resources is important if your group is struggling with this!
 * Maintain multiple {{ site.data.spell.fs }} using [Unstable Matter Orbs](https://www.wowhead.com/spell=363518/unstable-matter) but **do not focus them until the boss is about to start casting** [Massive Bang](https://www.wowhead.com/spell=363533/massive-bang)
-       
+
 **Defensives:**
-       
+
 * Use {{ site.data.spell.astral_shift }} as needed with [Dark Eclipse](https://www.wowhead.com/spell=361548/dark-eclipse), ideally use it before stepping into a [Collapsing Quasar Field](https://www.wowhead.com/spell=361462/collapsing-quasar-field) so it also covers the [Dark Collapse](https://www.wowhead.com/spell=361463/dark-collapse). Don't forget you need to move **out** of the raid before this goes off!
 
-       
+
 **Utilities:**
-       
+
 * {{ site.data.talent.wrt }} is very useful to help your group position for [Massive Bang](https://www.wowhead.com/spell=363533/massive-bang), as you need to be stood in the zones left by [Burned Out Unstable Matter](https://www.wowhead.com/spell=363518/unstable-matter) in order to avoid lethal damage.
 * {{ site.data.spell.earthbind_totem }} is very useful to slow [Collapsing Quasar Orbs](https://www.wowhead.com/npc=182778/collapsing-quasar).    
-  
+
 </div>
 </div>
 </div>
-    
+
 <div class="card">
 <div class="card-header" id="zovaal">
 <div data-toggle="collapse" data-target="#zovaal-collapse" aria-expanded="true" aria-controls="zovaal-collapse" class="raid-header sepulcher_of_the_first_ones11"><h2>The Jailer, Zovaal</h2></div>
 </div>
 <div id="zovaal-collapse" class="collapse" aria-labelledby="zovaal" data-parent="#accordion">
 <div class="card-body" markdown="1">    
-  
-**Boss Fight Profile:** Single Target 
-          
+
+**Boss Fight Profile:** Single Target
+
 **Talents:**
 
 **Talents without {{ site.data.item.t28_4 }}:**
 
 * **15:** {{ site.data.talent.echo_of_the_elements }}
-* **25:** {{ site.data.talent.elemental_blast }} 
+* **25:** {{ site.data.talent.elemental_blast }}
 * **30:** {{ site.data.talent.spirit_wolf }}
 * **35:** {{ site.data.talent.se }} or {{ site.data.talent.master_of_the_elements }}
 * **40:** {{ site.data.talent.wind_rush_totem }} or {{ site.data.talent.natures_guardian }}
 * **45:** {{ site.data.talent.icefury }} or {{ site.data.talent.pe }}
 * **50:** {{ site.data.talent.stormkeeper }}
-       
+
 **Talents with {{ site.data.item.t28_4 }}:**
-       
+
 * **15:** {{ site.data.talent.eote }}
 * **25:** {{ site.data.talent.eb }}
 * **30:** {{ site.data.talent.spirit_wolf }}
@@ -702,33 +702,33 @@ The tips and recommendations listed here are based on educated opinions from PTR
 * **40:** {{ site.data.talent.wrt }} or {{ site.data.talent.natures_guardian }}
 * **45:** {{ site.data.talent.pe }}
 * **50:** {{ site.data.talent.sk }} or {{ site.data.talent.asc }}
- 
+
 **Recommended Covenant:**   
-       
+
 * Night Fae with Dreamweaver (consider Niya if you would otherwise have poor {{ site.data.soulbinds.field_of_blossom }} uptime and/or delay {{ site.data.spell.fae_transfusion }} in order to facilitate uptime)
 * Necrolord with Plague-Deviser Marileth
-       
+
 **Recommended Legendaries:**
 
 * {{ site.data.legendary.wlr }}
-       
+
 **Damage**
-       
+
 * Pool resources to help break [Rune of Compulsion Mind Control](https://www.wowhead.com/spell=366285/rune-of-compulsion).
-       
+
 **Defensives:**
-       
+
 * Use {{ site.data.spell.astral_shift }} as needed for soaking [Martyrdom's](https://www.wowhead.com/spell=363893/martyrdom) final blow with your tank or [Desolation](https://www.wowhead.com/spell=365033/desolation)
-       
+
 **Utilities:**
-       
+
 * {{ site.data.talent.wrt }} is very useful to help your group avoid [Oppression](https://www.wowhead.com/spell=362617/oppression)
-* {{ site.data.talent.tremor_totem }} can be used to break your own Mind Control by placing {{ site.data.talent.tremor_totem }} when you are targeted by [Rune of Compulsion](https://www.wowhead.com/spell=366285/rune-of-compulsion), it does not remove Mind Control from your allies and you cannot cast {{ site.data.talent.tremor_totem }} during the Mind Control itself. 
-       
+* {{ site.data.talent.tremor_totem }} can be used to break your own Mind Control by placing {{ site.data.talent.tremor_totem }} when you are targeted by [Rune of Compulsion](https://www.wowhead.com/spell=366285/rune-of-compulsion), it does not remove Mind Control from your allies and you cannot cast {{ site.data.talent.tremor_totem }} during the Mind Control itself.
+
 **Additional Notes:**
 
 * You can use the knock-up portion of [Rune of Damnation](https://www.wowhead.com/spell=360282/rune-of-damnation) to reposition depending on which way you face when stepping into the `Pylon Conduit`, it will push you the opposite way from where you are facing.
-  
+
 </div>
 </div>
 </div>  

--- a/guide/raids/season_4.md
+++ b/guide/raids/season_4.md
@@ -1,6 +1,6 @@
 ---
 title: "Season Four, Raiding and YOU!"
-date: 06/08/2022
+last_update: 06/08/2022
 game_version: 9.2.5 Shadowlands
 author: Eokira
 toc: false
@@ -27,7 +27,7 @@ toc: false
 
 - Broadly, no. The most significant difference Elemental will have in Season Four compared to what we had when clearing the previous raids is carrying the {{ site.data.item.t28_4 }} bonus with us, which results in our build choices remaining largely the same as they were in Season 3 just applied to previous content bosses.
 
-# Where can I find boss-specific information? or information about M+? 
+# Where can I find boss-specific information? or information about M+?
 
 - Raids:
     - [Castle Nathria](https://stormearthandlava.com/guide/raids/nathria.html)

--- a/guide/raids/vault.md
+++ b/guide/raids/vault.md
@@ -1,10 +1,11 @@
 ---
 layout: page
 title: "Vault of the Incarnates Guide"
-date: 22/03/2023
+last_update: 22/03/2023
 game_version: 10.0.7 Dragonflight
 author: Sheffy, Elivrio
 toc: false
+big_article: false
 ---
 
 # Introduction
@@ -13,14 +14,16 @@ This guide was made possible by:
 - Altenna (Discord: JudgeJames#0001 \| [Twitch](https://www.twitch.tv/judgejames) \| [Twitter](https://twitter.com/_judgejames_))
 - Amani (Discord: Amani#0001 \| [Discord Server (RU)](https://discord.gg/vodovorot) \| [Twitch](https://www.twitch.tv/amanizandalari))
 - Bloodmallet (Discord: Bloodmallet(EU)#8246 \| [Website](https://bloodmallet.com/))
+- Elivrio (Discord: Elivrio#1450, in-game : Tyrindra-Ysondre)
 - Eokira (Discord: Eokira#7823)
 - Gaka (Discord: Gaka#7410)
 - HawkCorrigan (Discord: HawkCorrigan#1811)
 - Kaldeak (Discord: Kaldeak#1394)
 - Sheffy (Discord: Sheffy#4928 \| [Twitch](https://www.twitch.tv/sheffywow) \| [Twitter](https://twitter.com/SheffyWoW))
-- Elivrio (Discord: Elivrio#1450, in-game : Tyrindra-Ysondre)
 
 The tips and recommendations listed here are based on educated opinions from PTR raid testing and reviewing logs and videos, so strategies can change as we develop a better understanding of each fight or as the spec and bosses are tuned. If you have any disagreements, feedback, or questions, please feel welcome to reach out to the team.
+
+<p align="center"><img src="/assets/img/blog/bluelinebreak.png" width="130%"/></p>
 
 # Miscellaneous Tips
 - Recommendations that include {{ site.data.talent.if }} are written with the assumption that you have access to {{ site.data.spell.frs }}, the same applies to {{ site.data.talent.lmt }}, {{ site.data.talent.totemic_recall }} and {{ site.data.talent.call_of_the_elements }}.
@@ -41,9 +44,9 @@ The tips and recommendations listed here are based on educated opinions from PTR
 
 
 # Bosses
-<p style="color:red">Click on a boss banner to expand it.</p>
 
-<hr>
+<p style="color:red" align="center">Click on a boss banner to expand it.</p>
+
 <div class="dungeon-accordion">
 <div id="accordion">
 <div class="card">

--- a/guide/raids/vault.md
+++ b/guide/raids/vault.md
@@ -23,7 +23,7 @@ This guide was made possible by:
 
 The tips and recommendations listed here are based on educated opinions from PTR raid testing and reviewing logs and videos, so strategies can change as we develop a better understanding of each fight or as the spec and bosses are tuned. If you have any disagreements, feedback, or questions, please feel welcome to reach out to the team.
 
-<p align="center"><img src="/assets/img/blog/bluelinebreak.png" width="130%"/></p>
+<hr>
 
 # Miscellaneous Tips
 - Recommendations that include {{ site.data.talent.if }} are written with the assumption that you have access to {{ site.data.spell.frs }}, the same applies to {{ site.data.talent.lmt }}, {{ site.data.talent.totemic_recall }} and {{ site.data.talent.call_of_the_elements }}.


### PR DESCRIPTION
- Layout improvement of Line break to better match the size of the website
- Updated the consumable data for it to display rank 3.
- Updated Consumable guide: 
     - Recommends vers in both raid and dungeon. Added a caveat for the static empower one in raid. 
     - Shuffled a few topics for better readability (imo, might be just me)
- Dungeon guide talent suggestion changed: 
     - I did a "recommended class tree" at the start of the guide, with optional picks and discussing the strength of those picks. 
     - Removed the builds from the dungeon banner, only some notable talent choices.
- Added Table of content in Build page with a new variable at the start of the articles to enable links such as https://stormearthandlava.com/guide/general/builds.html#lightning-builds

@Bloodmallet @Eokira24601 