### PR TITLE
Aberrus Raid Guide  - Edit

### DIFF
--- a/_data/raid/aberrus.yml
+++ b/_data/raid/aberrus.yml
@@ -13,70 +13,71 @@
 # Replace PLAIN_NAME  with the appropriate base name
 
 # Kazzara
-dread_rift: <a href="https://www.wowhead.com/ptr/spell=406526/dread-rift" target="blank">Dread Rift</a>
-hellbeam: <a href="https://www.wowhead.com/ptr/spell=400430/hellbeam" target="blank">Hellbeam</a>
-infernal_fusion: <a href="https://www.wowhead.com/ptr/spell=408147/infernal-fusion" target="blank">Infernal Fusion</a>
-infernal_heart: <a href="https://www.wowhead.com/ptr/spell=408367/infernal-heart" target="blank">Infernal Heart</a>
-rays_of_anguish: <a href="https://www.wowhead.com/ptr/spell=407069/rays-of-anguish" target="blank">Rays of Anguish</a>
+dread_rift: <a href="https://www.wowhead.com/spell=406526/dread-rift" target="blank">Dread Rift</a>
+hellbeam: <a href="https://www.wowhead.com/spell=400430/hellbeam" target="blank">Hellbeam</a>
+infernal_fusion: <a href="https://www.wowhead.com/spell=408147/infernal-fusion" target="blank">Infernal Fusion</a>
+infernal_heart: <a href="https://www.wowhead.com/spell=408367/infernal-heart" target="blank">Infernal Heart</a>
+rays_of_anguish: <a href="https://www.wowhead.com/spell=407069/rays-of-anguish" target="blank">Rays of Anguish</a>
 
 # The Amalgamation Chamber
-blazing_heat: <a href="https://www.wowhead.com/ptr/spell=402617/blazing-heat" target="blank">Blazing Heat</a>
-blistering_twilight: <a href="https://www.wowhead.com/ptr/spell=405643/blistering_twilight" target="blank">Blistering Twilight</a>
-coalescing_void: <a href="https://www.wowhead.com/ptr/spell=403559/coalescing-void" target="blank">Coalescing Void</a>
-corrupting_shadow: <a href="https://www.wowhead.com/ptr/spell=401809/corrupting-shadow" target="blank">Corrupting Shadow</a>
-essence_of_shadow: <a href="https://www.wowhead.com/ptr/npc=201774/essence-of-shadow" target="blank">Essence of Shadow</a>
-eternal_blaze: <a href="https://www.wowhead.com/ptr/npc=201773/eternal-blaze" target="blank">Eternal Blaze</a>
-lingering_flames: <a href="https://www.wowhead.com/ptr/spell=409320/lingering-flames" target="blank">Lingering Flames</a>
-lingering_shadows: <a href="https://www.wowhead.com/ptr/spell=409299/lingering-shadows" target="blank">Lingering Shadows</a>
-shadowflame_contamination: <a href="https://www.wowhead.com/ptr/spell=405394/shadowflame-contamination" target="blank">Shadowflame Contamination</a>
-umbral_detonation: <a href="https://www.wowhead.com/ptr/spell=405082/umbral-detonation" target="blank">Umbral Detonation</a>
+blazing_heat: <a href="https://www.wowhead.com/spell=402617/blazing-heat" target="blank">Blazing Heat</a>
+blistering_twilight: <a href="https://www.wowhead.com/spell=405643/blistering_twilight" target="blank">Blistering Twilight</a>
+coalescing_void: <a href="https://www.wowhead.com/spell=403559/coalescing-void" target="blank">Coalescing Void</a>
+corrupting_shadow: <a href="https://www.wowhead.com/spell=401809/corrupting-shadow" target="blank">Corrupting Shadow</a>
+essence_of_shadow: <a href="https://www.wowhead.com/npc=201774/essence-of-shadow" target="blank">Essence of Shadow</a>
+eternal_blaze: <a href="https://www.wowhead.com/npc=201773/eternal-blaze" target="blank">Eternal Blaze</a>
+lingering_flames: <a href="https://www.wowhead.com/spell=409320/lingering-flames" target="blank">Lingering Flames</a>
+lingering_shadows: <a href="https://www.wowhead.com/spell=409299/lingering-shadows" target="blank">Lingering Shadows</a>
+shadowflame_contamination: <a href="https://www.wowhead.com/spell=405394/shadowflame-contamination" target="blank">Shadowflame Contamination</a>
+umbral_detonation: <a href="https://www.wowhead.com/spell=405082/umbral-detonation" target="blank">Umbral Detonation</a>
 
 # The Forgotten Experiments
-deep_breath: <a href="https://www.wowhead.com/ptr/spell=406227/deep-breath" target="blank">Deep Breath</a>
-erratic_remnant: <a href="https://www.wowhead.com/ptr/npc=202824/erratic-remnant" target="blank">Erratic Remnants</a>
-erratic_burst: <a href="https://www.wowhead.com/ptr/spell=408476/erratic-burst" target="blank">Erratic Burst</a>
-massive_slam: <a href="https://www.wowhead.com/ptr/spell=407733/massive-slam" target="blank">Massive Slam</a>
-rending_charge: <a href="https://www.wowhead.com/ptr/spell=406358/rending-charge" target="blank">Rending Charge</a>
-unstable_essence: <a href="https://www.wowhead.com/ptr/spell=407327/unstable-essence" target="blank">Unstable Essence</a>
+deep_breath: <a href="https://www.wowhead.com/spell=406227/deep-breath" target="blank">Deep Breath</a>
+erratic_remnant: <a href="https://www.wowhead.com/npc=202824/erratic-remnant" target="blank">Erratic Remnants</a>
+erratic_burst: <a href="https://www.wowhead.com/spell=408476/erratic-burst" target="blank">Erratic Burst</a>
+massive_slam: <a href="https://www.wowhead.com/spell=407733/massive-slam" target="blank">Massive Slam</a>
+rending_charge: <a href="https://www.wowhead.com/spell=406358/rending-charge" target="blank">Rending Charge</a>
+unstable_essence: <a href="https://www.wowhead.com/spell=407327/unstable-essence" target="blank">Unstable Essence</a>
 
 # Assault of the Zaqali
-cave_rubble: <a href="https://www.wowhead.com/ptr/spell=400450/cave-rubble" target="blank">Cave Rubble</a>
-flaming_cudgel: <a href="https://www.wowhead.com/ptr/spell=410369/flaming-cudgel" target="blank">Flaming Cudgel</a>
-magma_mystic: <a href="https://www.wowhead.com/ptr/npc=199703/magma-mystic" target="blank">Magma Mystics</a>
-molten_barrier: <a href="https://www.wowhead.com/ptr/spell=409242/molten-barrier" target="blank">Molten Barrier</a>
-renewed_hatchling: <a href="https://www.wowhead.com/ptr/npc=201738/renewed-hatchling" target="blank">Renewed Hatchlings</a>
-vigorous_gale: <a href="https://www.wowhead.com/ptr/spell=407017/vigorous-gale" target="blank">Vigorous Gale</a>
-zaqali_wallclimber: <a href="https://www.wowhead.com/ptr/npc=205617/zaqali-wallclimber" target="blank">Zaqali Wallclimbers</a>
+cave_rubble: <a href="https://www.wowhead.com/spell=400450/cave-rubble" target="blank">Cave Rubble</a>
+flaming_cudgel: <a href="https://www.wowhead.com/spell=410369/flaming-cudgel" target="blank">Flaming Cudgel</a>
+magma_mystic: <a href="https://www.wowhead.com/npc=199703/magma-mystic" target="blank">Magma Mystics</a>
+molten_barrier: <a href="https://www.wowhead.com/spell=409242/molten-barrier" target="blank">Molten Barrier</a>
+renewed_hatchling: <a href="https://www.wowhead.com/npc=201738/renewed-hatchling" target="blank">Renewed Hatchlings</a>
+vigorous_gale: <a href="https://www.wowhead.com/spell=407017/vigorous-gale" target="blank">Vigorous Gale</a>
+zaqali_wallclimber: <a href="https://www.wowhead.com/npc=205617/zaqali-wallclimber" target="blank">Zaqali Wallclimbers</a>
 
 # Rashok
-charged_smash: <a href="https://www.wowhead.com/ptr/spell=405825/charged-smash" target="blank">Charged Smash</a>
-conduit_flare: <a href="https://www.wowhead.com/ptr/spell=405828/conduit-flare" target="blank">Conduit Flare</a>
-doom_flames: <a href="https://www.wowhead.com/ptr/spell=406851/doom-flames" target="blank">Doom Flames</a>
-overcharged: <a href="https://www.wowhead.com/ptr/spell=405827/overcharged" target="blank">Overcharged</a>
-scorching_heatwave: <a href="https://www.wowhead.com/ptr/spell=404448/scorching-heatwave" target="blank">Scorching Heatwave</a>
-searing_slam: <a href="https://www.wowhead.com/ptr/spell=405819/searing-slam" target="blank">Searing Slam</a>
+charged_smash: <a href="https://www.wowhead.com/spell=405825/charged-smash" target="blank">Charged Smash</a>
+conduit_flare: <a href="https://www.wowhead.com/spell=405828/conduit-flare" target="blank">Conduit Flare</a>
+doom_flames: <a href="https://www.wowhead.com/spell=406851/doom-flames" target="blank">Doom Flames</a>
+overcharged: <a href="https://www.wowhead.com/spell=405827/overcharged" target="blank">Overcharged</a>
+scorching_heatwave: <a href="https://www.wowhead.com/spell=404448/scorching-heatwave" target="blank">Scorching Heatwave</a>
+searing_slam: <a href="https://www.wowhead.com/spell=405819/searing-slam" target="blank">Searing Slam</a>
 
 #zskarn
-blast_wave: <a href="https://www.wowhead.com/ptr/spell=403978/blast-wave" target="blank">Blast Wave</a>
-dragonfire_golem: <a href="https://www.wowhead.com/ptr/npc=203230/dragonfire-golem" target="blank">Dragonfire Golems</a>
-elimination_protocol: <a href="https://www.wowhead.com/ptr/spell=409942/elimination-protocol" target="blank">Elimination Protocol</a>
-tactical_destruction: <a href="https://www.wowhead.com/ptr/spell=406207/tactical-destruction" target="blank">Tactical Destruction</a>
-unstable_embers: <a href="https://www.wowhead.com/ptr/spell=404404/unstable-embers" target="blank">Unstable Embers</a>
+blast_wave: <a href="https://www.wowhead.com/spell=403978/blast-wave" target="blank">Blast Wave</a>
+dragonfire_golem: <a href="https://www.wowhead.com/npc=203230/dragonfire-golem" target="blank">Dragonfire Golems</a>
+elimination_protocol: <a href="https://www.wowhead.com/spell=409942/elimination-protocol" target="blank">Elimination Protocol</a>
+tactical_destruction: <a href="https://www.wowhead.com/spell=406207/tactical-destruction" target="blank">Tactical Destruction</a>
+unstable_embers: <a href="https://www.wowhead.com/spell=404404/unstable-embers" target="blank">Unstable Embers</a>
+reinforced_defenses: <a href="https://www.wowhead.com/spell=409462/reinforced-defenses" target="blank">Reinforced Defenses</a>
 
 # Magmorax
-blazing_breath: <a href="https://www.wowhead.com/ptr/spell=409093/blazing-breath" target="blank">Blazing Breath</a>
-igniting_roar: <a href="https://www.wowhead.com/ptr/spell=403747/igniting-roar" target="blank">Igniting Roar</a>
-molten_spittle: <a href="https://www.wowhead.com/ptr/spell=402989/molten-spittle" target="blank">Molten Spittle</a>
-overpowering_stomp: <a href="https://www.wowhead.com/ptr/spell=403671/overpowering-stomp" target="blank">Overpowering Stomp</a>
-searing_heat: <a href="https://www.wowhead.com/ptr/spell=408839/searing-heat" target="blank">Searing Heat</a>
+blazing_breath: <a href="https://www.wowhead.com/spell=409093/blazing-breath" target="blank">Blazing Breath</a>
+igniting_roar: <a href="https://www.wowhead.com/spell=403747/igniting-roar" target="blank">Igniting Roar</a>
+molten_spittle: <a href="https://www.wowhead.com/spell=402989/molten-spittle" target="blank">Molten Spittle</a>
+overpowering_stomp: <a href="https://www.wowhead.com/spell=403671/overpowering-stomp" target="blank">Overpowering Stomp</a>
+searing_heat: <a href="https://www.wowhead.com/spell=408839/searing-heat" target="blank">Searing Heat</a>
 
 # Echo of Neltharion
-rushing_darkness: <a href="https://www.wowhead.com/ptr/spell=407220/rushing-darkness" target="blank">Rushing Darkness</a>
-surrender_to_corruption: <a href="https://www.wowhead.com/ptr/spell=407048/surrender-to-corruption" target="blank">Surrender to Corruption</a>
-twisted_aberration: <a href="https://www.wowhead.com/ptr/npc=202814/twisted-aberration" target="blank">Twisted Aberrations</a>
-umbral_annihilation: <a href="https://www.wowhead.com/ptr/spell=405434/umbral-annihilation" target="blank">Umbral Annihilation</a>
-voice_from_beyond: <a href="https://www.wowhead.com/ptr/npc=203812/voice-from-beyond" target="blank">Voices From Beyond</a>
-volcanic_heart: <a href="https://www.wowhead.com/ptr/spell=410953/volcanic-heart" target="blank">Volcanic Heart</a>
+rushing_darkness: <a href="https://www.wowhead.com/spell=407220/rushing-darkness" target="blank">Rushing Darkness</a>
+surrender_to_corruption: <a href="https://www.wowhead.com/spell=407048/surrender-to-corruption" target="blank">Surrender to Corruption</a>
+twisted_aberration: <a href="https://www.wowhead.com/npc=202814/twisted-aberration" target="blank">Twisted Aberrations</a>
+umbral_annihilation: <a href="https://www.wowhead.com/spell=405434/umbral-annihilation" target="blank">Umbral Annihilation</a>
+voice_from_beyond: <a href="https://www.wowhead.com/npc=203812/voice-from-beyond" target="blank">Voices From Beyond</a>
+volcanic_heart: <a href="https://www.wowhead.com/spell=410953/volcanic-heart" target="blank">Volcanic Heart</a>
 
 # Sarkareth
 SHORTCUT: <a href="https://shadowlands.wowhead.com/TYPE=ID" target="blank">PLAIN_NAME</a>

--- a/guide/raids/aberrus.md
+++ b/guide/raids/aberrus.md
@@ -289,15 +289,9 @@ The tips and recommendations listed here are based on educated opinions from PTR
   </iframe>
 </div>
 
-#### Lightning in Normal/Heroic:
+#### Lightning:
 <div class="iframe-holder">
   <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAoVSSLJUSSLRDRJQiEAAAAAgSAJlkQaCItkkWIgQIBC?width=530&level=70" frameborder="0" width="530px" height="100%">
-  </iframe>
-</div>
-
-#### Lightning in Mythic:
-<div class="iframe-holder">
-  <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAoVSSLJJFSLRDRJQiEAAAAAgSAJlkolmASLJpFOAIESgA?width=530&level=70" frameborder="0" width="530px" height="100%">
   </iframe>
 </div>
 

--- a/guide/raids/aberrus.md
+++ b/guide/raids/aberrus.md
@@ -27,7 +27,7 @@ The tips and recommendations listed here are based on educated opinions from PTR
 # Miscellaneous Tips
 - Recommendations that include {{ site.data.talent.if }} are written with the assumption that you have access to {{ site.data.spell.frs }}, the same applies to {{ site.data.talent.lmt }}, {{ site.data.talent.totemic_recall }} and {{ site.data.talent.call_of_the_elements }}.
 
-- The final boss [Scalecommander Sarkareth](https://www.wowhead.com/ptr/npc=205319/scalecommander-sarkareth) was not tested on PTR so no footage for those bosses exists.
+- The final boss [Scalecommander Sarkareth](https://www.wowhead.com/npc=205319/scalecommander-sarkareth) was not tested on PTR so no footage for those bosses exists.
 
 - GCDs spent on healing and utilities are GCDs not spent on damage, but both are necessary to down a raid boss. Find the balance to optimize your contributions to your raid team.
 
@@ -58,17 +58,17 @@ The tips and recommendations listed here are based on educated opinions from PTR
 
 ### Talents
 
-#### T29/T30 2-piece:
+#### Fire:
 
 <div class="iframe-holder">
-  <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAgUSpUSCAJlkUoEUSSSEAAAAAgSAJlkgmASLJpFASSCBC?width=530&level=70" frameborder="0" width="530px" height="100%">
+  <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAgUSpUSCAJlkUoEUSSSEAAAAAgSAJlkgmASLJpFCIkIBC?width=530&level=70" frameborder="0" width="530px" height="100%">
   </iframe>
 </div>
 
-#### T30 4-piece:
+#### Lightning:
 
 <div class="iframe-holder">
-  <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAoVSSLJUSSLRDRJQiEAAAAAgSAJlkgmASLJpFASSCBC?width=530&level=70" frameborder="0" width="530px" height="100%">
+  <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAoVSSLJUSSLRDRJQiEAAAAAgSAJlkgmASLJpFCIRIBC?width=530&level=70" frameborder="0" width="530px" height="100%">
   </iframe>
 </div>
 
@@ -103,15 +103,15 @@ The tips and recommendations listed here are based on educated opinions from PTR
 
 ### Talents:
 
-#### T29/T30 2-piece:
+#### Fire:
 <div class="iframe-holder">
-  <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAgUSpUSCAJlkUoEUSSSEAAAAAgSAJlkgmASLJpFASSCBC?width=530&level=70" frameborder="0" width="530px" height="100%">
+  <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAgUSpUSCAJlkUoEUSSSEAAAAAgSAJlkgmASLJpFCIkIBC?width=530&level=70" frameborder="0" width="530px" height="100%">
   </iframe>
 </div>
 
-#### T30 4-piece:
+#### Lightning:
 <div class="iframe-holder">
-  <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAoVSSLJUSSLRDRJQiEAAAAAgSAJlkgmASLJpFASSCBC?width=530&level=70" frameborder="0" width="530px" height="100%">
+  <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAoVSSLJUSSLRDRJQiEAAAAAgSAJlkgmASLJpFCIRIBC?width=530&level=70" frameborder="0" width="530px" height="100%">
   </iframe>
 </div>
 
@@ -148,21 +148,21 @@ The tips and recommendations listed here are based on educated opinions from PTR
 
 ### Talents:
 
-#### T29/T30 2-piece:
+#### Fire:
 <div class="iframe-holder">
   <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAgUSpUSCAJlkUoEUSSSEAAAAAgSASJJoJQSLJpFQhkkAI?width=530&level=70" frameborder="0" width="530px" height="100%">
   </iframe>
 </div>
 
-#### T30 4-piece in Normal/Heroic:
+#### Lightning in Normal/Heroic:
 <div class="iframe-holder">
-  <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAoVSSLJUSSLRDRJQiEAAAAAgSASJJoJQSLJpFQhkkAI?width=530&level=70" frameborder="0" width="530px" height="100%">
+  <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAoVSSLJUSSLRDRJQiEAAAAAgSAJlkgmAJtkkW4AUIESgA?width=530&level=70" frameborder="0" width="530px" height="100%">
   </iframe>
 </div>
 
-#### T30 4-piece in Mythic:
+#### Lightning in Mythic:
 <div class="iframe-holder">
-  <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAoVSSLJSRSLRDRJQiEAAAAAgSASJJoJQSLJpFQhkkAI?width=530&level=70" frameborder="0" width="530px" height="100%">
+  <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAoVSSLJSRSLRDRJQiEAAAAAgSAJlkgmAJtkkW4AUIESgA?width=530&level=70" frameborder="0" width="530px" height="100%">
   </iframe>
 </div>
 
@@ -199,7 +199,7 @@ The tips and recommendations listed here are based on educated opinions from PTR
 
 ### Talents:
 
-#### T29 and T30
+#### Lightning:
 <div class="iframe-holder">
   <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAoVSSJJJlDk0S0QQDJSAAAAAAKBIlkokmASLJpdgSAJEBI?width=530&level=70" frameborder="0" width="530px" height="100%">
   </iframe>
@@ -240,15 +240,15 @@ The tips and recommendations listed here are based on educated opinions from PTR
 
 ### Talents
 
-#### T29/T30 2-piece:
+#### Fire:
 <div class="iframe-holder">
-  <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAgUSpUSCAJlkUoEUSSSEAAAAAgSAJlkgmASLJpFASSCBC?width=530&level=70" frameborder="0" width="530px" height="100%">
+  <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAgUSpUSCAJlkUoEUSSSEAAAAAgSAJlkgmASLJpFCIkIBC?width=530&level=70" frameborder="0" width="530px" height="100%">
   </iframe>
 </div>
 
-#### T30 4-piece:
+#### Lightning:
 <div class="iframe-holder">
-  <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAoVSSLJUSSLRDRJQiEAAAAAgSAJlkgmASLJpFASSCBC?width=530&level=70" frameborder="0" width="530px" height="100%">
+  <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAoVSSLJUSSLRDRJQiEAAAAAgSAJlkgmASLJpFCIRIBC?width=530&level=70" frameborder="0" width="530px" height="100%">
   </iframe>
 </div>
 
@@ -283,15 +283,15 @@ The tips and recommendations listed here are based on educated opinions from PTR
 
 ### Talents
 
-#### T29/T30 2-piece:
+#### Fire:
 <div class="iframe-holder">
   <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAgUSpIJtkAJtIFKBNJJBAAAAAgSASJJkmASLJplSACJBI?width=530&level=70" frameborder="0" width="530px" height="100%">
   </iframe>
 </div>
 
-#### T30 4-piece:
+#### Lightning:
 <div class="iframe-holder">
-  <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAoVSSLJSRSLRDRJQiEAAAAAgSASJJapJg0SSaBgkkAI?width=530&level=70" frameborder="0" width="530px" height="100%">
+  <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAoVSSLJSRSLRDRJQiEAAAAAgSAJlkolmASLJpFOAIESgA?width=530&level=70" frameborder="0" width="530px" height="100%">
   </iframe>
 </div>
 
@@ -309,6 +309,7 @@ The tips and recommendations listed here are based on educated opinions from PTR
 * Use {{ site.data.spell.healing_surge }} if necessary.
 
 #### Utilities:
+* Use {{ site.data.talent.capacitor_totem }} and {{ site.data.spell.earthgrab_totem }} if talented to gather and stun as many {{ site.data.raid.aberrus.dragonfire_golem }} as possible but keep in mind that {{ site.data.raid.aberrus.reinforced_defenses }} (Mythic-only) will prevent you from applying those CCs.
 * Use {{ site.data.talent.wrt }} to help players repositioning during {{ site.data.raid.aberrus.tactical_destruction }}.
 </div>
 </div>
@@ -325,15 +326,15 @@ The tips and recommendations listed here are based on educated opinions from PTR
 
 #### Talents:
 
-#### T29/T30 2-piece:
+#### Fire:
 <div class="iframe-holder">
-  <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAgUSpUSCAJlkUoEUSSSEAAAAAgSAJlkgmASLJpFASSCBC?width=530&level=70" frameborder="0" width="530px" height="100%">
+  <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAgUSpUSCAJlkUoEUSSSEAAAAAgSAJlkgmASLJpFCIkIBC?width=530&level=70" frameborder="0" width="530px" height="100%">
   </iframe>
 </div>
 
-#### T30 4-piece:
+#### Lightning:
 <div class="iframe-holder">
-  <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAoVSSLJUSSLRDRJQiEAAAAAgSAJlkgmASLJpFASSCBC?width=530&level=70" frameborder="0" width="530px" height="100%">
+  <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAoVSSLJUSSLRDRJQiEAAAAAgSAJlkgmASLJpFCIRIBC?width=530&level=70" frameborder="0" width="530px" height="100%">
   </iframe>
 </div>
 
@@ -371,15 +372,15 @@ The tips and recommendations listed here are based on educated opinions from PTR
 
 ### Talents:
 
-#### T29/T30 2-piece:
+#### Fire:
 <div class="iframe-holder">
-  <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAgUSpIJtkAJINKBlkkkDAAAAAAoEQSJJoJg0SSaBgkkQgA?width=530&level=70" frameborder="0" width="530px" height="100%">
+  <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAgUSpIJtkAJINKBlkkkDAAAAAAoEQSJJoJg0SSahACJSgA?width=530&level=70" frameborder="0" width="530px" height="100%">
   </iframe>
 </div>
 
-#### T30 4-piece:
+#### Lightning:
 <div class="iframe-holder">
-  <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAoVSSLJUSSLRDRJQiEAAAAAgSAJlkgmASLJpFASSCBC?width=530&level=70" frameborder="0" width="530px" height="100%">
+  <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAoVSSLJUSSLRDRJQiEAAAAAgSAJlkgmASLJpFCIRIBC?width=530&level=70" frameborder="0" width="530px" height="100%">
   </iframe>
 </div>
 
@@ -389,7 +390,7 @@ The tips and recommendations listed here are based on educated opinions from PTR
 
 #### Damage:
 * Use {{ site.data.talent.sk }} and  {{ site.data.talent.fe }} / {{ site.data.talent.se }} to burst down {{ site.data.raid.aberrus.voice_from_beyond }}.
-* Prepare an {{ site.data.talent.eogs }} buff when {{ site.data.raid.aberrus.twisted_aberration }} are about to spawn.
+* If talented, prepare an {{ site.data.talent.eogs }} buff when {{ site.data.raid.aberrus.twisted_aberration }} are about to spawn.
 * Use {{ site.data.talent.swg }} and {{ site.data.talent.gow }} to maintain uptime whilst dealing with {{ site.data.raid.aberrus.rushing_darkness }} and {{ site.data.raid.aberrus.volcanic_heart }} (Mythic-only).
 
 #### Defensives:

--- a/guide/raids/aberrus.md
+++ b/guide/raids/aberrus.md
@@ -289,9 +289,15 @@ The tips and recommendations listed here are based on educated opinions from PTR
   </iframe>
 </div>
 
-#### Lightning:
+#### Lightning in Normal/Heroic:
 <div class="iframe-holder">
-  <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAoVSSLJSRSLRDRJQiEAAAAAgSAJlkolmASLJpFOAIESgA?width=530&level=70" frameborder="0" width="530px" height="100%">
+  <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAoVSSLJUi0S0QUSDJSAAAAAAKBIlkolmASLJplSACRAC?width=530&level=70" frameborder="0" width="530px" height="100%">
+  </iframe>
+</div>
+
+#### Lightning in Mythic:
+<div class="iframe-holder">
+  <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAoVSSLJJFSLRDRJQiEAAAAAgSAJlkolmASLJpFOAIESgA?width=530&level=70" frameborder="0" width="530px" height="100%">
   </iframe>
 </div>
 

--- a/guide/raids/aberrus.md
+++ b/guide/raids/aberrus.md
@@ -291,7 +291,7 @@ The tips and recommendations listed here are based on educated opinions from PTR
 
 #### Lightning in Normal/Heroic:
 <div class="iframe-holder">
-  <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAoVSSLJUi0S0QUSDJSAAAAAAKBIlkolmASLJplSACRAC?width=530&level=70" frameborder="0" width="530px" height="100%">
+  <iframe src="https://www.raidbots.com/simbot/render/talents/BYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAoVSSLJUSSLRDRJQiEAAAAAgSAJlkQaCItkkWIgQIBC?width=530&level=70" frameborder="0" width="530px" height="100%">
   </iframe>
 </div>
 


### PR DESCRIPTION
Site data:
- PTR links replaced
- Reinforced Defenses of Dragonfire Golems added to Zskarn

Raid guide:
- small changes/additions to Zskarn + Echo of Neltharion
- talent build header (example: "T29/T30 2-piece") changed to "Fire" or "Lightning"
- talent strings updated (added Elemental Orbit/Surging Shields to the class tree
