### PR TITLE
Update to ele101 list

### DIFF
--- a/blog/_posts/2023-01-23-ele101.md
+++ b/blog/_posts/2023-01-23-ele101.md
@@ -31,8 +31,8 @@ Spell | Abbreviation
 {{ site.data.spell.frs }} | FrS
 {{ site.data.spell.ghost_wolf }} | GW / Wolf
 {{ site.data.spell.healing_stream_totem }} | HST
-{{ site.data.spell.healing_surge }} | HS
-{{ site.data.spell.lvbm }} | LvBm
+#{{ site.data.spell.healing_surge }} | HS
+#{{ site.data.spell.lvbm }} | LvBm
 {{ site.data.spell.lvb }} | LvB
 {{ site.data.spell.lb }} | LB
 {{ site.data.spell.lightning_shield }} | LS
@@ -47,26 +47,26 @@ Spell | Abbreviation
 Cooldown | Abbreviation
 :---: | :---:
 {{ site.data.spell.asc }} | Asc
-{{ site.data.spell.ag }} | AG
+#{{ site.data.spell.ag }} | AG
 {{ site.data.spell.as }} | AS
 {{ site.data.spell.bl }} | BL / Hero / Lust
 {{ site.data.spell.capacitor_totem }} | Cap Totem / Cap
 {{ site.data.spell.ee }} | EE / Steve / Rocky
 {{ site.data.spell.fe }} | FE / Fred
 {{ site.data.spell.gow }} | Gust / GoW
-{{ site.data.spell.if }} | IF
-{{ site.data.spell.lmt }} | LMT
+#{{ site.data.spell.if }} | IF
+#{{ site.data.spell.lmt }} | LMT
 {{ site.data.spell.ns }} | NS
 {{ site.data.spell.pct }} | PCT
-{{ site.data.spell.pw }} | PW
+#{{ site.data.spell.pw }} | PW
 {{ site.data.spell.ankh }} | Ankh
 {{ site.data.spell.spirit_walk }} | SW
 {{ site.data.spell.swg }} | SWG
 {{ site.data.spell.se }} | SE / Sean
 {{ site.data.spell.sk }} | SK
-{{ site.data.spell.thunderstorm }} | TS
-{{ site.data.spell.totemic_recall }} | TR
-{{ site.data.spell.tremor_totem }} | Tremor / TT
+{{ site.data.spell.thunderstorm }} | TStorm
+#{{ site.data.spell.totemic_recall }} | TR
+{{ site.data.spell.tremor_totem }} | Tremor
 {{ site.data.spell.wrt }} | WRT
 
 </div>
@@ -78,37 +78,37 @@ Cooldown | Abbreviation
 Passive | Abbreviation
 :---: | :---:
 {{ site.data.spell.afs }} | Afs
-{{ site.data.spell.brimming_with_life }} | BwL
-{{ site.data.spell.dre }} | DRE
-{{ site.data.spell.earth_shield }} | EaS
+#{{ site.data.spell.brimming_with_life }} | BwL
+#{{ site.data.spell.dre }} | DRE
+{{ site.data.spell.earth_shield }} | EaS / EShield
 {{ site.data.spell.echo_chamber }} | EC
 {{ site.data.spell.eote }} | EotE
 {{ site.data.spell.eogs }} | EoGS
-{{ site.data.spell.electrified_shocks }} | ElS / EShocks
-{{ site.data.spell.eeq }} | EEq
+#{{ site.data.spell.electrified_shocks }} | ElS / EShocks
+#{{ site.data.spell.eeq }} | EEq
 {{ site.data.spell.eots }} | EotS
 {{ site.data.spell.flames_of_the_cauldron }} | FotC
 {{ site.data.spell.fol }} | FoL
-{{ site.data.spell.flow_of_power }} | Flow / FoP
-{{ site.data.spell.flux_melting }} | Flux / FM
-{{ site.data.spell.fb }} | FB
-{{ site.data.spell.imp_flametongue_weapon }} | IFW / IFT
+#{{ site.data.spell.flow_of_power }} | Flow / FoP
+#{{ site.data.spell.flux_melting }} | Flux / FM
+#{{ site.data.spell.fb }} | FB
+#{{ site.data.spell.imp_flametongue_weapon }} | IFW / IFT
 {{ site.data.spell.lvs }} | LvS
 {{ site.data.spell.lr }} | LR
-{{ site.data.spell.magma_chamber }} | MC
-{{ site.data.spell.ms }} | MS
+#{{ site.data.spell.magma_chamber }} | MC
+#{{ site.data.spell.ms }} | MS
 {{ site.data.spell.mote }} | MotE
 {{ site.data.spell.mwf }} | MWF
 {{ site.data.spell.natures_guardian }} | NG
 {{ site.data.spell.potm }} | PotM
 {{ site.data.spell.pe }} | PE
-{{ site.data.spell.ps }} | PS / Psurge
-{{ site.data.spell.sf }} | SF
-{{ site.data.spell.sfd }} | SFD
-{{ site.data.spell.splinter }} | SpE / Splintered
-{{ site.data.spell.sop }} | SoP
-{{ site.data.spell.thunderous_paws }} | TP
-{{ site.data.spell.thundershock }} | TShocks
-{{ site.data.spell.wlr }} | WLR
+#{{ site.data.spell.ps }} | PS / Psurge
+#{{ site.data.spell.sf }} | SF
+#{{ site.data.spell.sfd }} | SFD
+#{{ site.data.spell.splinter }} | SpE / Splintered
+#{{ site.data.spell.sop }} | SoP
+{{ site.data.spell.thunderous_paws }} | TPaws
+#{{ site.data.spell.thundershock }} | TShocks
+#{{ site.data.spell.wlr }} | WLR
 
 </div>

--- a/blog/_posts/2023-01-23-ele101.md
+++ b/blog/_posts/2023-01-23-ele101.md
@@ -21,6 +21,7 @@ Spell | Abbreviation
 :---: | :---:
 {{ site.data.spell.cl }} | CL
 {{ site.data.spell.cleanse_spirit }} | Decurse / Cleanse
+{{ site.data.spell.earth_shield }} | EaS / EShield
 {{ site.data.spell.es }} | ES
 {{ site.data.spell.earthbind_totem }} | EBT
 {{ site.data.spell.earthgrab_totem }} | EGT
@@ -71,7 +72,6 @@ Cooldown | Abbreviation
 Passive | Abbreviation
 :---: | :---:
 {{ site.data.spell.afs }} | Afs
-{{ site.data.spell.earth_shield }} | EaS / EShield
 {{ site.data.spell.echo_chamber }} | EC
 {{ site.data.spell.eote }} | EotE
 {{ site.data.spell.eogs }} | EoGS

--- a/blog/_posts/2023-01-23-ele101.md
+++ b/blog/_posts/2023-01-23-ele101.md
@@ -31,8 +31,6 @@ Spell | Abbreviation
 {{ site.data.spell.frs }} | FrS
 {{ site.data.spell.ghost_wolf }} | GW / Wolf
 {{ site.data.spell.healing_stream_totem }} | HST
-#{{ site.data.spell.healing_surge }} | HS
-#{{ site.data.spell.lvbm }} | LvBm
 {{ site.data.spell.lvb }} | LvB
 {{ site.data.spell.lb }} | LB
 {{ site.data.spell.lightning_shield }} | LS
@@ -47,25 +45,20 @@ Spell | Abbreviation
 Cooldown | Abbreviation
 :---: | :---:
 {{ site.data.spell.asc }} | Asc
-#{{ site.data.spell.ag }} | AG
 {{ site.data.spell.as }} | AS
 {{ site.data.spell.bl }} | BL / Hero / Lust
 {{ site.data.spell.capacitor_totem }} | Cap Totem / Cap
 {{ site.data.spell.ee }} | EE / Steve / Rocky
 {{ site.data.spell.fe }} | FE / Fred
 {{ site.data.spell.gow }} | Gust / GoW
-#{{ site.data.spell.if }} | IF
-#{{ site.data.spell.lmt }} | LMT
 {{ site.data.spell.ns }} | NS
 {{ site.data.spell.pct }} | PCT
-#{{ site.data.spell.pw }} | PW
 {{ site.data.spell.ankh }} | Ankh
 {{ site.data.spell.spirit_walk }} | SW
 {{ site.data.spell.swg }} | SWG
 {{ site.data.spell.se }} | SE / Sean
 {{ site.data.spell.sk }} | SK
 {{ site.data.spell.thunderstorm }} | TStorm
-#{{ site.data.spell.totemic_recall }} | TR
 {{ site.data.spell.tremor_totem }} | Tremor
 {{ site.data.spell.wrt }} | WRT
 
@@ -78,37 +71,20 @@ Cooldown | Abbreviation
 Passive | Abbreviation
 :---: | :---:
 {{ site.data.spell.afs }} | Afs
-#{{ site.data.spell.brimming_with_life }} | BwL
-#{{ site.data.spell.dre }} | DRE
 {{ site.data.spell.earth_shield }} | EaS / EShield
 {{ site.data.spell.echo_chamber }} | EC
 {{ site.data.spell.eote }} | EotE
 {{ site.data.spell.eogs }} | EoGS
-#{{ site.data.spell.electrified_shocks }} | ElS / EShocks
-#{{ site.data.spell.eeq }} | EEq
 {{ site.data.spell.eots }} | EotS
 {{ site.data.spell.flames_of_the_cauldron }} | FotC
 {{ site.data.spell.fol }} | FoL
-#{{ site.data.spell.flow_of_power }} | Flow / FoP
-#{{ site.data.spell.flux_melting }} | Flux / FM
-#{{ site.data.spell.fb }} | FB
-#{{ site.data.spell.imp_flametongue_weapon }} | IFW / IFT
 {{ site.data.spell.lvs }} | LvS
 {{ site.data.spell.lr }} | LR
-#{{ site.data.spell.magma_chamber }} | MC
-#{{ site.data.spell.ms }} | MS
 {{ site.data.spell.mote }} | MotE
 {{ site.data.spell.mwf }} | MWF
 {{ site.data.spell.natures_guardian }} | NG
 {{ site.data.spell.potm }} | PotM
 {{ site.data.spell.pe }} | PE
-#{{ site.data.spell.ps }} | PS / Psurge
-#{{ site.data.spell.sf }} | SF
-#{{ site.data.spell.sfd }} | SFD
-#{{ site.data.spell.splinter }} | SpE / Splintered
-#{{ site.data.spell.sop }} | SoP
 {{ site.data.spell.thunderous_paws }} | TPaws
-#{{ site.data.spell.thundershock }} | TShocks
-#{{ site.data.spell.wlr }} | WLR
 
 </div>


### PR DESCRIPTION
- Removed talents and abilities that got pruned
- Moved Earth Shield to spells since it is an active ability (even though it became passive with new talents KEKW)
- Removed/renamed few spells that just dont work:
  - HS is "hearthstone", there is just no good way to shorten healing surge without being confusing imo
  - TS is referencing time spiral or teamspeak or anything else from other classes and games more often in Earthshrine search than actual thunderstorm so -> Tstorm
  - TP - that's "teleport", same problem as HS  -> Tpaws
  - BwL is just not smth ppl use (or talk about or care about), all search results are about black wing lair xD